### PR TITLE
Closes #78 - Allow multiple LdapContextSource beans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ Thumbs.db
 
 # DB2 database
 db.tar.gz
+.codiumai

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapConfiguration.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapConfiguration.java
@@ -18,17 +18,21 @@
 
 package io.kadai.common.rest.ldap;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.ldap.core.support.LdapContextSource;
 
 /** Configuration for Ldap access. */
 @Configuration
 public class LdapConfiguration {
 
+  public static final String KADAI_LDAP_CONTEXT_SOURCE = "kadaiLdapContextSource";
   private final String ldapServerUrl;
   private final String ldapBaseDn;
   private final String ldapBindDn;
@@ -45,9 +49,9 @@ public class LdapConfiguration {
     this.ldapBindPassword = ldapBindPassword;
   }
 
-  @Bean
-  @ConditionalOnMissingBean(LdapContextSource.class)
-  public LdapContextSource ldapContextSource() {
+  @Bean(name = KADAI_LDAP_CONTEXT_SOURCE)
+  @ConditionalOnMissingBean(name = KADAI_LDAP_CONTEXT_SOURCE)
+  public BaseLdapPathContextSource ldapContextSource() {
     LdapContextSource contextSource = new LdapContextSource();
     contextSource.setUrl(ldapServerUrl);
     contextSource.setBase(ldapBaseDn);
@@ -58,7 +62,8 @@ public class LdapConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(LdapTemplate.class)
-  public LdapTemplate ldapTemplate(LdapContextSource ldapContextSource) {
+  public LdapTemplate ldapTemplate(
+      @Qualifier(KADAI_LDAP_CONTEXT_SOURCE) ContextSource ldapContextSource) {
     return new LdapTemplate(ldapContextSource);
   }
 }


### PR DESCRIPTION
<!-- if needed please write above the given line -->

### Thanks for your PR! Please fill out the following list :)

---

- [ ] I put the ticket or multiple tickets in review
- [x] Commit message format → Closes #&lt;Issue Number&gt; - Your commit message.
- [x] Sonarcloud link : https://sonarcloud.io/summary/new_code?id=CRoberto1926_kadai&branch=feature%2FKAD-62-multiple-context-source-beans
- [ ] No documentation update needed
- [x] Link to PR with documentation update: https://github.com/kadai-io/kadai-doc/pull/14
- [ ] No Release Notes needed
- [x] Release Notes :

<!-- Please write your release notes between ```-->

```
- Allow more than one LdapContextSource bean to be created
```