### PR TITLE
Closes #46 - Move should_DeleteOldWorkbasketCleanupJobs_When_InitializingSchedule to AbstractKadaiJobAccTest.java

### DIFF
--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/AbstractKadaiJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/AbstractKadaiJobAccTest.java
@@ -40,11 +40,11 @@ import io.kadai.testapi.KadaiConfigurationModifier;
 import io.kadai.testapi.KadaiInject;
 import io.kadai.testapi.KadaiIntegrationTest;
 import io.kadai.testapi.security.WithAccessId;
+import io.kadai.workbasket.internal.jobs.WorkbasketCleanupJob;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.AfterEach;
@@ -56,6 +56,11 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 
+/**
+ * Acceptance test for the AbstractKadaiJob class.
+ * This is not an abstract test class, but a concrete test implementation that verifies
+ * the functionality of the AbstractKadaiJob class.
+ */
 @KadaiIntegrationTest
 class AbstractKadaiJobAccTest {
 
@@ -74,6 +79,7 @@ class AbstractKadaiJobAccTest {
     jobMapper.deleteMultiple(TaskRefreshJob.class.getName());
     jobMapper.deleteMultiple(ClassificationChangedJob.class.getName());
     jobMapper.deleteMultiple(HistoryCleanupJob.class.getName());
+    jobMapper.deleteMultiple(WorkbasketCleanupJob.class.getName());
   }
 
   @WithAccessId(user = "admin")
@@ -102,11 +108,12 @@ class AbstractKadaiJobAccTest {
 
   @WithAccessId(user = "admin")
   @TestFactory
-  Stream<DynamicTest> should_DeleteOldCleanupJobs_When_InitializingSchedule() throws Exception {
+  Stream<DynamicTest> should_DeleteOldCleanupJobs_When_InitializingSchedule() {
     List<Pair<String, Class<?>>> testCases =
         List.of(
             Pair.of("Delete Old Task Cleanup Jobs", TaskCleanupJob.class),
-            Pair.of("Delete Old History Cleanup Jobs", HistoryCleanupJob.class));
+            Pair.of("Delete Old History Cleanup Jobs", HistoryCleanupJob.class),
+            Pair.of("Delete Old Workbasket Cleanup Jobs", WorkbasketCleanupJob.class));
     ThrowingConsumer<Pair<String, Class<?>>> test =
         t -> {
           for (int i = 0; i < 10; i++) {
@@ -124,7 +131,7 @@ class AbstractKadaiJobAccTest {
           List<ScheduledJob> cleanupJobs =
               jobsToRun.stream()
                   .filter(scheduledJob -> scheduledJob.getType().equals(t.getRight().getName()))
-                  .collect(Collectors.toList());
+                  .toList();
 
           AbstractKadaiJob.initializeSchedule(kadaiEngine, t.getRight());
 

--- a/lib/kadai-core/src/test/java/acceptance/jobs/WorkbasketCleanupJobAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/jobs/WorkbasketCleanupJobAccTest.java
@@ -21,21 +21,15 @@ package acceptance.jobs;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import acceptance.AbstractAccTest;
-import io.kadai.classification.internal.jobs.ClassificationChangedJob;
 import io.kadai.common.api.BaseQuery;
-import io.kadai.common.api.ScheduledJob;
-import io.kadai.common.internal.jobs.AbstractKadaiJob;
 import io.kadai.common.test.security.JaasExtension;
 import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.internal.jobs.TaskCleanupJob;
-import io.kadai.task.internal.jobs.TaskRefreshJob;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
 import io.kadai.workbasket.internal.jobs.WorkbasketCleanupJob;
-import java.time.Instant;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -104,37 +98,6 @@ class WorkbasketCleanupJobAccTest extends AbstractAccTest {
 
     totalWorkbasketCount = workbasketService.createWorkbasketQuery().count();
     assertThat(totalWorkbasketCount).isEqualTo(26);
-  }
-
-  @WithAccessId(user = "admin")
-  @Test
-  void should_DeleteOldWorkbasketCleanupJobs_When_InitializingSchedule() throws Exception {
-
-    for (int i = 0; i < 10; i++) {
-      ScheduledJob job = new ScheduledJob();
-      job.setType(WorkbasketCleanupJob.class.getName());
-      kadaiEngine.getJobService().createJob(job);
-      job.setType(TaskRefreshJob.class.getName());
-      kadaiEngine.getJobService().createJob(job);
-      job.setType(ClassificationChangedJob.class.getName());
-      kadaiEngine.getJobService().createJob(job);
-    }
-
-    List<ScheduledJob> jobsToRun = getJobMapper(kadaiEngine).findJobsToRun(Instant.now());
-
-    assertThat(jobsToRun).hasSize(30);
-
-    List<ScheduledJob> workbasketCleanupJobs =
-        jobsToRun.stream()
-            .filter(
-                scheduledJob -> scheduledJob.getType().equals(WorkbasketCleanupJob.class.getName()))
-            .collect(Collectors.toList());
-
-    AbstractKadaiJob.initializeSchedule(kadaiEngine, WorkbasketCleanupJob.class);
-
-    jobsToRun = getJobMapper(kadaiEngine).findJobsToRun(Instant.now());
-
-    assertThat(jobsToRun).doesNotContainAnyElementsOf(workbasketCleanupJobs);
   }
 
   private long getNumberTaskNotCompleted(String workbasketId) {


### PR DESCRIPTION
Closes #46 - Move should_DeleteOldWorkbasketCleanupJobs_When_InitializingSchedule to AbstractKadaiJobAccTest.java
<!-- if needed please write above the given line -->

### Thanks for your PR! Please fill out the following list :)

---

- [ ] I put the ticket or multiple tickets in review
- [x] Commit message format → Closes #&lt;Issue Number&gt; - Your commit message.
- [x] Sonarcloud link : https://sonarcloud.io/summary/new_code?id=jannikFuellgrafEnvite_kadai&branch=kadai%2F46
- [x] No documentation update needed
- [ ] Link to PR with documentation update: \<add the link here>
- [x] No Release Notes needed
- [ ] Release Notes :

<!-- Please write your release notes between ```-->

```

```