### PR TITLE
Closes #357 - add a new ldap attribute for group access id

### DIFF
--- a/rest/kadai-rest-spring-example-common/src/main/resources/kadai-example.ldif
+++ b/rest/kadai-rest-spring-example-common/src/main/resources/kadai-example.ldif
@@ -416,6 +416,7 @@ uniquemember: uid=teamlead-2,cn=users,OU=Test,O=KADAI
 cn: monitor-users
 objectclass: groupofuniquenames
 objectclass: top
+gid: monitor-users-id
 
 ########################
 # Permissions

--- a/rest/kadai-rest-spring-example-common/src/test/java/io/kadai/example/ldap/LdapGroupAndPermissionIdAttributeTest.java
+++ b/rest/kadai-rest-spring-example-common/src/test/java/io/kadai/example/ldap/LdapGroupAndPermissionIdAttributeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright [2024] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.example.ldap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kadai.common.rest.models.AccessIdRepresentationModel;
+import io.kadai.rest.test.KadaiSpringBootTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+/** Test Ldap attachment. */
+@KadaiSpringBootTest
+@TestPropertySource(properties = {"kadai.ldap.useDnForGroups=false",
+    "kadai.ldap.groupIdAttribute=gid", "kadai.ldap.permissionIdAttribute=pid"})
+@ActiveProfiles({"emptySearchRoots"})
+class LdapGroupAndPermissionIdAttributeTest extends LdapForUseDnForGroupsDisabledTest {
+
+  @Override
+  @Test
+  void should_FindGroupsForUser_When_UserIdIsProvided() throws Exception {
+    List<AccessIdRepresentationModel> groups =
+        ldapClient.searchGroupsAccessIdIsMemberOf("user-2-2");
+    assertThat(groups)
+        .extracting(AccessIdRepresentationModel::getAccessId)
+        .containsExactlyInAnyOrder("ksc-users", "organisationseinheit ksc 2");
+  }
+
+  @Test
+  void should_ReturnFullDnForGroup_When_AccessIdOfGroupIsGiven() throws Exception {
+    String dn = ldapClient.searchDnForAccessId("monitor-users-id");
+    assertThat(dn).isEqualTo("cn=monitor-users,cn=groups,ou=test,o=kadai");
+  }
+
+  @Test
+  void should_ReturnGroupWithMatchingAccessId_When_SearchingUsersGroupsAndPermissions()
+      throws Exception {
+    List<AccessIdRepresentationModel> accessIds = ldapClient.searchUsersAndGroupsAndPermissions(
+        "monitor-users-id");
+    assertThat(accessIds)
+        .extracting(AccessIdRepresentationModel::getAccessId)
+        .containsExactlyInAnyOrder("monitor-users-id");
+  }
+
+  @Test
+  void should_ReturnPermissionWithMatchingAccessId_When_SearchingUsersGroupsAndPermissions()
+      throws Exception {
+    List<AccessIdRepresentationModel> accessIds = ldapClient.searchUsersAndGroupsAndPermissions(
+        "g03-permission-id");
+    assertThat(accessIds)
+        .extracting(AccessIdRepresentationModel::getAccessId)
+        .containsExactlyInAnyOrder("g03-permission-id");
+  }
+
+
+}

--- a/rest/kadai-rest-spring-test-lib/src/main/resources/kadai-test.ldif
+++ b/rest/kadai-rest-spring-test-lib/src/main/resources/kadai-test.ldif
@@ -394,6 +394,7 @@ uniquemember: uid=user-2-2,cn=users,OU=Test,O=KADAI
 cn: ksc-users
 objectclass: groupofuniquenames
 objectclass: top
+gid: ksc-users
 
 dn: cn=ksc-teamleads,cn=groups,OU=Test,O=KADAI
 uniquemember: uid=teamlead-1,cn=users,OU=Test,O=KADAI
@@ -401,6 +402,7 @@ uniquemember: uid=teamlead-2,cn=users,OU=Test,O=KADAI
 cn: ksc-teamleads
 objectclass: groupofuniquenames
 objectclass: top
+gid: ksc-teamleads
 
 dn: cn=business-admins,cn=groups,OU=Test,O=KADAI
 uniquemember: uid=teamlead-1,cn=users,OU=Test,O=KADAI
@@ -416,6 +418,7 @@ uniquemember: uid=teamlead-2,cn=users,OU=Test,O=KADAI
 cn: monitor-users
 objectclass: groupofuniquenames
 objectclass: top
+gid: monitor-users-ID
 
 ########################
 # Permissions
@@ -428,6 +431,7 @@ permission: Kadai:CallCenter:AB:AB/A:CallCenter
 cn: g01
 objectclass: groupofuniquenames
 objectclass: top
+pid: Kadai:CallCenter:AB:AB/A:CallCenter
 
 dn: cn=g02,cn=groups,OU=Test,O=KADAI
 uniquemember: uid=user-1-2,cn=users,OU=Test,O=KADAI
@@ -435,6 +439,16 @@ permission: Kadai:CallCenter:AB:AB/A:CallCenter-vip
 cn: g02
 objectclass: groupofuniquenames
 objectclass: top
+pid: Kadai:CallCenter:AB:AB/A:CallCenter-vip
+
+
+dn: cn=g03,cn=groups,OU=Test,O=KADAI
+permission: permission-name
+cn: g02
+objectclass: groupofuniquenames
+objectclass: top
+pid: g03-permission-id
+
 
 ######################
 # Organizational Units
@@ -469,6 +483,7 @@ uniquemember: uid=user-2-10,cn=users,OU=Test,O=KADAI
 cn: Organisationseinheit KSC 2
 objectclass: groupofuniquenames
 objectclass: top
+gid: Organisationseinheit KSC 2
 
 dn: cn=Organisationseinheit B,cn=organisation,OU=Test,O=KADAI
 cn: Organisationseinheit B

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapSettings.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapSettings.java
@@ -20,7 +20,9 @@ package io.kadai.common.rest.ldap;
 
 import org.springframework.core.env.Environment;
 
-/** Required settings to run ldap. */
+/**
+ * Required settings to run ldap.
+ */
 enum LdapSettings {
   KADAI_LDAP_USER_SEARCH_BASE("kadai.ldap.userSearchBase"),
   KADAI_LDAP_USER_SEARCH_FILTER_NAME("kadai.ldap.userSearchFilterName"),
@@ -42,11 +44,13 @@ enum LdapSettings {
   KADAI_LDAP_PERMISSION_SEARCH_FILTER_NAME("kadai.ldap.permissionSearchFilterName"),
   KADAI_LDAP_PERMISSION_SEARCH_FILTER_VALUE("kadai.ldap.permissionSearchFilterValue"),
   KADAI_LDAP_PERMISSION_NAME_ATTRIBUTE("kadai.ldap.permissionNameAttribute"),
+  KADAI_LDAP_PERMISSION_ID_ATTRIBUTE("kadai.ldap.permissionIdAttribute"),
   KADAI_LDAP_GROUP_SEARCH_BASE("kadai.ldap.groupSearchBase"),
   KADAI_LDAP_BASE_DN("kadai.ldap.baseDn"),
   KADAI_LDAP_GROUP_SEARCH_FILTER_NAME("kadai.ldap.groupSearchFilterName"),
   KADAI_LDAP_GROUP_SEARCH_FILTER_VALUE("kadai.ldap.groupSearchFilterValue"),
   KADAI_LDAP_GROUP_NAME_ATTRIBUTE("kadai.ldap.groupNameAttribute"),
+  KADAI_LDAP_GROUP_ID_ATTRIBUTE("kadai.ldap.groupIdAttribute"),
   KADAI_LDAP_MIN_SEARCH_FOR_LENGTH("kadai.ldap.minSearchForLength"),
   KADAI_LDAP_MAX_NUMBER_OF_RETURNED_ACCESS_IDS("kadai.ldap.maxNumberOfReturnedAccessIds"),
   KADAI_LDAP_GROUPS_OF_USER("kadai.ldap.groupsOfUser"),

--- a/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ldap/LdapClientTest.java
+++ b/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ldap/LdapClientTest.java
@@ -247,11 +247,12 @@ class LdapClientTest {
 
   @Test
   void testLdap_checkForMissingConfigurations() {
-    // optional config fields: minSearchForLength, maxNumberOfReturnedAccessIds, userPhoneAttribute,
-    // userMobilePhoneAttribute, userEmailAttribute, userOrglevel1Attribute, userOrglevel2Attribute,
-    // userOrglevel3Attribute, userOrglevel4Attribute, groupsOfUser, groupsOfUserName,
-    // groupOfUserType
-    assertThat(cut.checkForMissingConfigurations()).hasSize(LdapSettings.values().length - 15);
+    // 17 optional config fields: minSearchForLength, maxNumberOfReturnedAccessIds,
+    // userPhoneAttribute, userMobilePhoneAttribute, userEmailAttribute, userOrglevel1Attribute,
+    // userOrglevel2Attribute, userOrglevel3Attribute, userOrglevel4Attribute, groupsOfUser,
+    // groupsOfUserName, groupOfUserType, groupIdAttribute, permissionIdAttribute,
+    // permissionsOfUser, permissionsOfUserType, permissionsOfUserName
+    assertThat(cut.checkForMissingConfigurations()).hasSize(LdapSettings.values().length - 17);
   }
 
   @Test


### PR DESCRIPTION
The test coverage in the sonarcloud evaluation is not accurate, as it doesn't recognize that some tests run with a configuration different from the default. Additionaly, there is one untested method in the LdapClient class that is currently discussed in #83.
<!-- if needed please write above the given line -->

### Thanks for your PR! Please fill out the following list :)

---

- [x] I put the ticket or multiple tickets in review
- [x] Commit message format → Closes #&lt;Issue Number&gt; - Your commit message.
- [x] Sonarcloud link : https://sonarcloud.io/summary/new_code?id=ryzheboka_kadai&branch=KAD-357 
- [ ] No documentation update needed
- [x] Link to PR with documentation update: https://github.com/kadai-io/kadai-doc/pull/45
- [x] No Release Notes needed
- [ ] Release Notes :

<!-- Please write your release notes between ```-->

```

```