### PR TITLE
Closes #202 - Simplify state transitions in `TaskServiceImpl::requestReview`

### DIFF
--- a/lib/kadai-core/src/main/java/io/kadai/task/api/TaskState.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/api/TaskState.java
@@ -31,6 +31,7 @@ public enum TaskState {
   TERMINATED;
 
   public static final TaskState[] END_STATES = {COMPLETED, CANCELLED, TERMINATED};
+  public static final TaskState[] CLAIMED_STATES = {CLAIMED, IN_REVIEW};
 
   public boolean in(TaskState... states) {
     return Arrays.asList(states).contains(this);
@@ -38,5 +39,9 @@ public enum TaskState {
 
   public boolean isEndState() {
     return in(END_STATES);
+  }
+
+  public boolean isClaimedState() {
+    return in(CLAIMED_STATES);
   }
 }


### PR DESCRIPTION
There was no bug. 
It seemed like there was one because the code checking the allowed state transitions was overly complex.
This PR reduces that complexity.

<!-- if needed please write above the given line -->

### Thanks for your PR! Please fill out the following list :)

---

- [x] I put the ticket or multiple tickets in review
- [x] Commit message format: Will be squashed on merge
- [ ] Sonarcloud link : \<add the link here>
- [x] No documentation update needed
- [ ] Link to PR with documentation update: \<add the link here>
- [x] No Release Notes needed
- [ ] Release Notes :

<!-- Please write your release notes between ```-->

```

```