### PR TITLE
Closes #41 - Add JavaDoc for test-api & add more abstraction to `EntityBuilder`

### DIFF
--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/CleanKadaiContext.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/CleanKadaiContext.java
@@ -23,6 +23,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation allowing to declare the cleansing of the KadaiContext in
+ * {@linkplain org.junit.jupiter.api.Nested @Nested} Test-Classes.
+ *
+ * <p>It makes the annotated class reuse the surrounding classes'
+ * {@linkplain javax.sql.DataSource DataSource} but generates a new schema.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @ExtendWith(KadaiInitializationExtension.class)
+ *     class MyTestClass {
+ *
+ *       @Nested
+ *       @CleanKadaiContext
+ *       @TestInstance(Lifecycle.PER_CLASS)
+ *       class MyNestedTestClass {}
+ *     }
+ *   }
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface CleanKadaiContext {}

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/CleanKadaiContext.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/CleanKadaiContext.java
@@ -24,25 +24,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation allowing to declare the cleansing of the KadaiContext in
- * {@linkplain org.junit.jupiter.api.Nested @Nested} Test-Classes.
+ * Annotation allowing to declare the cleansing of the KadaiContext in {@linkplain
+ * org.junit.jupiter.api.Nested @Nested} Test-Classes.
  *
- * <p>It makes the annotated class reuse the surrounding classes'
- * {@linkplain javax.sql.DataSource DataSource} but generates a new schema.
+ * <p>It makes the annotated class reuse the surrounding classes' {@linkplain javax.sql.DataSource
+ * DataSource} while generating a new {@linkplain io.kadai.common.api.KadaiEngine KadaiEngine} and
+ * schema.
  *
  * <p>Usage may look like:
- * <pre>
- *   {@code
- *     @ExtendWith(KadaiInitializationExtension.class)
- *     class MyTestClass {
  *
- *       @Nested
- *       @CleanKadaiContext
- *       @TestInstance(Lifecycle.PER_CLASS)
- *       class MyNestedTestClass {}
- *     }
- *   }
- * </pre>
+ * <pre>{@code
+ * @ExtendWith(KadaiInitializationExtension.class)
+ * class MyTestClass {
+ *
+ *   @Nested
+ *   @CleanKadaiContext
+ *   @TestInstance(Lifecycle.PER_CLASS)
+ *   class MyNestedTestClass {}
+ * }
+ *
+ * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/DefaultTestEntities.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/DefaultTestEntities.java
@@ -31,18 +31,33 @@ import io.kadai.workbasket.api.WorkbasketType;
 import java.util.Random;
 import java.util.UUID;
 
+/**
+ * Utility-Class providing prepared
+ * {@linkplain io.kadai.testapi.builder.EntityBuilder Entity-Builders} to build default entities
+ * for tests.
+ */
 public class DefaultTestEntities {
 
   private DefaultTestEntities() {
     throw new IllegalStateException("Utility class");
   }
 
+  /**
+   * Returns the default {@link ClassificationBuilder}.
+   *
+   * @return the default {@link ClassificationBuilder}
+   */
   public static ClassificationBuilder defaultTestClassification() {
     return newClassification()
         .key(UUID.randomUUID().toString().replace("-", ""))
         .domain("DOMAIN_A");
   }
 
+  /**
+   * Returns the default {@link WorkbasketBuilder}.
+   *
+   * @return the default {@link WorkbasketBuilder}
+   */
   public static WorkbasketBuilder defaultTestWorkbasket() {
     return newWorkbasket()
         .key(UUID.randomUUID().toString())
@@ -52,6 +67,11 @@ public class DefaultTestEntities {
         .orgLevel1("company");
   }
 
+  /**
+   * Returns the default {@link ObjectReferenceBuilder}.
+   *
+   * @return the default {@link ObjectReferenceBuilder}
+   */
   public static ObjectReferenceBuilder defaultTestObjectReference() {
     return newObjectReference()
         .company("Company1")
@@ -61,6 +81,13 @@ public class DefaultTestEntities {
         .value("Value1");
   }
 
+  /**
+   * Returns a {@link UserBuilder} with random {@linkplain UserBuilder#id(String) id},
+   * {@linkplain UserBuilder#firstName(String) firstName} and
+   * {@linkplain UserBuilder#lastName(String) lastName}.
+   *
+   * @return the default {@link ClassificationBuilder}
+   */
   public static UserBuilder randomTestUser() {
     return newUser()
         .id(UUID.randomUUID().toString().replace("-", ""))

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/DockerContainerCreator.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/DockerContainerCreator.java
@@ -31,12 +31,22 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * Utility-Class for creating dockerized databases and obtaining their
+ * {@linkplain DataSource DataSources}.
+ */
 public class DockerContainerCreator {
 
   private DockerContainerCreator() {
     throw new IllegalStateException("Utility class");
   }
 
+  /**
+   * Creates a {@link JdbcDatabaseContainer} for a {@linkplain DB database}.
+   *
+   * @param db the database to create the container for
+   * @return the container for the database if creation was successful, nothing otherwise
+   */
   public static Optional<JdbcDatabaseContainer<?>> createDockerContainer(DB db) {
     switch (db) {
       case DB2:
@@ -84,6 +94,12 @@ public class DockerContainerCreator {
     }
   }
 
+  /**
+   * Creates a {@link DataSource} from a {@link JdbcDatabaseContainer}.
+   *
+   * @param container the container to create the data source from
+   * @return the created data source
+   */
   public static DataSource createDataSource(JdbcDatabaseContainer<?> container) {
     PooledDataSource ds =
         new PooledDataSource(

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiConfigurationModifier.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiConfigurationModifier.java
@@ -20,7 +20,35 @@ package io.kadai.testapi;
 
 import io.kadai.KadaiConfiguration;
 
+/**
+ * Interface specifying operations allowing to modify the {@link KadaiConfiguration} of an
+ * integration test extended with
+ * {@linkplain
+ * io.kadai.testapi.extensions.KadaiInitializationExtension @KadaiInitializationExtension}.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @ExtendWith(KadaiInitializationExtension.class)
+ *     class MyTestClass implements KadaiEngineConfigurationModifier {
+ *       @Override
+ *       public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+ *         return builder.foo();
+ *       }
+ *
+ *       @Test
+ *       void myTest() {}
+ *     }
+ *   }
+ *  * </pre>
+ */
 public interface KadaiConfigurationModifier {
 
+  /**
+   * Modifies the {@link KadaiConfiguration.Builder}.
+   *
+   * @param builder the builder to modify
+   * @return the modified builder
+   */
   KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder);
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiEngineProxy.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiEngineProxy.java
@@ -24,7 +24,7 @@ import io.kadai.common.internal.KadaiEngineImpl;
 import java.lang.reflect.Field;
 import org.apache.ibatis.session.SqlSession;
 
-/** Utility class to enable unit tests to access mappers directly. */
+/** Proxy class to grant tests access to the {@link InternalKadaiEngine}. */
 public class KadaiEngineProxy {
 
   private final InternalKadaiEngine engine;
@@ -35,18 +35,39 @@ public class KadaiEngineProxy {
     engine = (InternalKadaiEngine) internal.get(kadaiEngine);
   }
 
+  /**
+   * Returns the underlying {@link InternalKadaiEngine}.
+   *
+   * @return the underlying internal engine
+   */
   public InternalKadaiEngine getEngine() {
     return engine;
   }
 
+  /**
+   * Returns the {@link SqlSession} used by the underlying {@link InternalKadaiEngine}.
+   *
+   * @return the session of the underlying internal engine
+   * @see InternalKadaiEngine#getSqlSession()
+   */
   public SqlSession getSqlSession() {
     return engine.getSqlSession();
   }
 
+  /**
+   * Opens a connection to the database for the underlying {@link InternalKadaiEngine}.
+   *
+   * @see InternalKadaiEngine#openConnection()
+   */
   public void openConnection() {
     engine.openConnection();
   }
 
+  /**
+   * Closes the connection to the database for the underlying {@link InternalKadaiEngine}.
+   *
+   * @see InternalKadaiEngine#returnConnection()
+   */
   public void returnConnection() {
     engine.returnConnection();
   }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiInject.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiInject.java
@@ -23,6 +23,28 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation allowing to inject Kadai components in Test-Classes.
+ *
+ * <p>This annotation requires the surrounding class to be extended with the JUnit-Extension
+ * {@linkplain
+ * io.kadai.testapi.extensions.KadaiDependencyInjectionExtension KadaiDependencyInjectionExtension}.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @ExtendWith(KadaiDependencyInjectionExtension.class)
+ *     class MyTestClass {
+ *       @KadaiInject InternalKadaiEngine internalKadaiEngine;
+ *
+ *       @Test
+ *       void myTest() {
+ *         internalKadaiEngine.foo(...);
+ *       }
+ *     }
+ *   }
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface KadaiInject {}

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiIntegrationTest.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/KadaiIntegrationTest.java
@@ -30,6 +30,39 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * Meta annotation for Kadai integration tests.
+ *
+ * <p>This annotation enables the following JUnit-Extensions:
+ *
+ * <ul>
+ *   <li>{@link JaasExtension}
+ *   <li>{@link TestContainerExtension}
+ *   <li>{@link KadaiInitializationExtension}
+ *   <li>{@link KadaiDependencyInjectionExtension}
+ * </ul>
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @KadaiIntegrationTest
+ *     class MyTestClass implements KadaiEngineConfigurationModifier {
+ *       @KadaiInject InternalKadaiEngine internalKadaiEngine;
+ *
+ *       @Override
+ *       public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+ *         return builder.foo();
+ *       }
+ *
+ *       @Test
+ *       @WithAccessId(user = "bar")
+ *       void myTest() {
+ *         internalKadaiEngine.baz(...);
+ *       }
+ *     }
+ *   }
+ * </pre>
+ */
 @ExtendWith({
   // ORDER IS IMPORTANT!
   JaasExtension.class,

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/WithServiceProvider.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/WithServiceProvider.java
@@ -25,19 +25,69 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation allowing to declare, define and register an SPI into the KadaiEngine of a Test-Class
+ * extended with
+ * {@linkplain
+ * io.kadai.testapi.extensions.KadaiInitializationExtension @KadaiInitializationExtension}.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @WithServiceProvider(
+ *       serviceProviderInterface = PriorityServiceProvider.class,
+ *       serviceProviders = TestStaticValuePriorityServiceProvider.class)
+ *     @ExtendWith(KadaiInitializationExtension.class)
+ *     class MyTestClass {
+ *       static class TestStaticValuePriorityServiceProvider implements PriorityServiceProvider {
+ *          @Override
+ *          public OptionalInt calculatePriority(TaskSummary taskSummary) {
+ *            return OptionalInt.of(10);
+ *          }
+ *        }
+ *
+ *       @Test
+ *       void myTest() {
+ *         // trigger some action that fires registered SPI
+ *       }
+ *     }
+ *   }
+ * </pre>
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(WithServiceProviders.class)
 public @interface WithServiceProvider {
 
+  /**
+   * Returns the type of the interface of the SPI to implement.
+   *
+   * @return the type of the interface of the SPI to implement
+   */
   Class<?> serviceProviderInterface();
 
+  /**
+   * Returns the types of the classes implementing the declared
+   * {@linkplain #serviceProviderInterface() ServiceProviderInterface}.
+   *
+   * @return the types of the classes implementing the declared
+   *     {@linkplain #serviceProviderInterface() ServiceProviderInterface}
+   */
   Class<?>[] serviceProviders();
 
+  /**
+   * Annotation allowing to declare multiple types of
+   * {@linkplain WithServiceProvider @WithServiceProvider}.
+   */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
   @interface WithServiceProviders {
 
+    /**
+     * Returns all declared {@linkplain WithServiceProvider @WithServiceProvider}.
+     *
+     * @return the array of all declared {@linkplain WithServiceProvider @WithServiceProvider}
+     */
     WithServiceProvider[] value();
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/Builder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/Builder.java
@@ -1,0 +1,16 @@
+package io.kadai.testapi.builder;
+
+/**
+ * Interface specifying how to build entities.
+ *
+ * @param <EntityT> the type of entity to build and store
+ */
+public interface Builder<EntityT> {
+
+  /**
+   * Builds the {@linkplain EntityT entity} for this builder.
+   *
+   * @return the built entity
+   */
+  EntityT build();
+}

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/ClassificationBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/ClassificationBuilder.java
@@ -28,7 +28,6 @@ import io.kadai.classification.api.models.ClassificationSummary;
 import io.kadai.common.api.exceptions.DomainNotFoundException;
 import io.kadai.common.api.exceptions.InvalidArgumentException;
 import io.kadai.common.api.exceptions.NotAuthorizedException;
-import io.kadai.testapi.builder.EntityBuilder.SummaryEntityBuilder;
 import java.time.Instant;
 
 public class ClassificationBuilder
@@ -147,5 +146,10 @@ public class ClassificationBuilder
     } finally {
       testClassification.setId(null);
     }
+  }
+
+  @Override
+  public Classification build() {
+    return testClassification.copy(testClassification.getId());
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/EntityBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/EntityBuilder.java
@@ -19,14 +19,36 @@
 package io.kadai.testapi.builder;
 
 import io.kadai.common.api.security.UserPrincipal;
+import io.kadai.user.api.models.User;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import javax.security.auth.Subject;
 
-public interface EntityBuilder<EntityT, ServiceT> {
+/**
+ * Interface specifying how to build and store entities in the database for integration tests.
+ *
+ * @param <EntityT> the type of entity to build and store
+ * @param <ServiceT> the type of the service for storing the entity
+ */
+public interface EntityBuilder<EntityT, ServiceT> extends Builder<EntityT> {
 
+  /**
+   * Builds the {@linkplain EntityT entity} for this builder and stores it in the database.
+   *
+   * @param service the {@linkplain ServiceT service} storing the built entity
+   * @return the stored entity
+   * @throws Exception if building or storing the entity fails
+   */
   EntityT buildAndStore(ServiceT service) throws Exception;
 
+  /**
+   * Builds the {@linkplain EntityT entity} for this builder and stores it in the database.
+   *
+   * @param service the {@linkplain ServiceT service} storing the built entity
+   * @param userId the {@linkplain User#getId() id} of the user to store the built entity as
+   * @return the stored entity
+   * @throws Exception if building or storing the entity fails
+   */
   default EntityT buildAndStore(ServiceT service, String userId) throws Exception {
     return execAsUser(userId, () -> buildAndStore(service));
   }
@@ -37,19 +59,5 @@ public interface EntityBuilder<EntityT, ServiceT> {
     subject.getPrincipals().add(new UserPrincipal(userId));
 
     return Subject.doAs(subject, runnable);
-  }
-
-  interface SummaryEntityBuilder<SummaryEntityT, EntityT extends SummaryEntityT, ServiceT>
-      extends EntityBuilder<EntityT, ServiceT> {
-    SummaryEntityT entityToSummary(EntityT entity);
-
-    default SummaryEntityT buildAndStoreAsSummary(ServiceT service) throws Exception {
-      return entityToSummary(buildAndStore(service));
-    }
-
-    default SummaryEntityT buildAndStoreAsSummary(ServiceT service, String userId)
-        throws Exception {
-      return entityToSummary(buildAndStore(service, userId));
-    }
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/ObjectReferenceBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/ObjectReferenceBuilder.java
@@ -21,7 +21,7 @@ package io.kadai.testapi.builder;
 import io.kadai.task.api.models.ObjectReference;
 import io.kadai.task.internal.models.ObjectReferenceImpl;
 
-public class ObjectReferenceBuilder {
+public class ObjectReferenceBuilder implements Builder<ObjectReference> {
 
   private final ObjectReferenceImpl objectReference = new ObjectReferenceImpl();
 
@@ -56,6 +56,7 @@ public class ObjectReferenceBuilder {
     return this;
   }
 
+  @Override
   public ObjectReference build() {
     return objectReference.copy();
   }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/SummaryEntityBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/SummaryEntityBuilder.java
@@ -1,0 +1,49 @@
+package io.kadai.testapi.builder;
+
+import io.kadai.user.api.models.User;
+
+/**
+ * Interface specifying how to build and store summary-entities in the database for integration
+ * tests.
+ *
+ * @param <SummaryEntityT> the type of the summary-entity to build and store
+ * @param <EntityT> the type of entity to build and store
+ * @param <ServiceT> the type of the service for storing the entity
+ */
+interface SummaryEntityBuilder<SummaryEntityT, EntityT extends SummaryEntityT, ServiceT>
+    extends EntityBuilder<EntityT, ServiceT> {
+
+  /**
+   * Converts an {@linkplain EntityT entity} to it's {@linkplain SummaryEntityT summary}.
+   *
+   * @param entity the entity to convert
+   * @return the summary of the entity
+   */
+  SummaryEntityT entityToSummary(EntityT entity);
+
+  /**
+   * Builds the {@linkplain SummaryEntityT summary} for this builder and stores it in the
+   * database.
+   *
+   * @param service the {@linkplain ServiceT service} storing the built summary
+   * @return the stored summary
+   * @throws Exception if building or storing the summary fails
+   */
+  default SummaryEntityT buildAndStoreAsSummary(ServiceT service) throws Exception {
+    return entityToSummary(buildAndStore(service));
+  }
+
+  /**
+   * Builds the {@linkplain SummaryEntityT summary} for this builder and stores it in the
+   * database.
+   *
+   * @param service the {@linkplain ServiceT service} storing the built summary
+   * @param userId the {@linkplain User#getId() id} of the user to store the built summary as
+   * @return the stored summary
+   * @throws Exception if building or storing the summary fails
+   */
+  default SummaryEntityT buildAndStoreAsSummary(ServiceT service, String userId)
+      throws Exception {
+    return entityToSummary(buildAndStore(service, userId));
+  }
+}

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskAttachmentBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskAttachmentBuilder.java
@@ -25,7 +25,7 @@ import io.kadai.task.internal.models.AttachmentImpl;
 import java.time.Instant;
 import java.util.Map;
 
-public class TaskAttachmentBuilder {
+public class TaskAttachmentBuilder implements Builder<Attachment> {
 
   private final AttachmentImpl attachment = new AttachmentImpl();
 
@@ -68,6 +68,7 @@ public class TaskAttachmentBuilder {
     return this;
   }
 
+  @Override
   public Attachment build() {
     AttachmentImpl a = attachment.copy();
     a.setTaskId(attachment.getTaskId());

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskBuilder.java
@@ -34,7 +34,6 @@ import io.kadai.task.api.models.Attachment;
 import io.kadai.task.api.models.ObjectReference;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
-import io.kadai.testapi.builder.EntityBuilder.SummaryEntityBuilder;
 import io.kadai.workbasket.api.exceptions.NotAuthorizedOnWorkbasketException;
 import io.kadai.workbasket.api.exceptions.WorkbasketNotFoundException;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
@@ -261,5 +260,10 @@ public class TaskBuilder implements SummaryEntityBuilder<TaskSummary, Task, Task
       testTask.setId(null);
       testTask.setExternalId(null);
     }
+  }
+
+  @Override
+  public Task build() {
+    return testTask.copy();
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskCommentBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/TaskCommentBuilder.java
@@ -77,4 +77,9 @@ public class TaskCommentBuilder implements EntityBuilder<TaskComment, TaskServic
       testTaskComment.setId(null);
     }
   }
+
+  @Override
+  public TaskComment build() {
+    return testTaskComment.copy();
+  }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/UserBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/UserBuilder.java
@@ -116,4 +116,9 @@ public class UserBuilder implements EntityBuilder<User, UserService> {
       throws UserAlreadyExistException, InvalidArgumentException, NotAuthorizedException {
     return userService.createUser(testUser);
   }
+
+  @Override
+  public User build() {
+    return testUser.copy();
+  }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/WorkbasketAccessItemBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/WorkbasketAccessItemBuilder.java
@@ -70,4 +70,9 @@ public class WorkbasketAccessItemBuilder
           NotAuthorizedException {
     return workbasketService.createWorkbasketAccessItem(testWorkbasketAccessItem);
   }
+
+  @Override
+  public WorkbasketAccessItem build() {
+    return testWorkbasketAccessItem.copy();
+  }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/WorkbasketBuilder.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/builder/WorkbasketBuilder.java
@@ -21,7 +21,6 @@ package io.kadai.testapi.builder;
 import io.kadai.common.api.exceptions.DomainNotFoundException;
 import io.kadai.common.api.exceptions.InvalidArgumentException;
 import io.kadai.common.api.exceptions.NotAuthorizedException;
-import io.kadai.testapi.builder.EntityBuilder.SummaryEntityBuilder;
 import io.kadai.workbasket.api.WorkbasketCustomField;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.WorkbasketType;
@@ -143,5 +142,10 @@ public class WorkbasketBuilder
     } finally {
       testWorkbasket.setId(null);
     }
+  }
+
+  @Override
+  public Workbasket build() {
+    return testWorkbasket.copy(testWorkbasket.getKey());
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiDependencyInjectionExtension.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiDependencyInjectionExtension.java
@@ -32,7 +32,22 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.platform.commons.JUnitException;
 
 /**
- * JUnit-Extension for injecting Kadai components via {@linkplain KadaiInject @KadaiInject}.
+ * JUnit-Extension for injecting Kadai components via {@linkplain KadaiInject @KadaiInject} or
+ * supplying them as parameter to test-functions.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @ExtendWith(KadaiDependencyInjectionExtension.class)
+ *     class MyTestClass {
+ *
+ *       @KadaiInject KadaiEngine kadaiEngine;
+ *
+ *       @Test
+ *       void myTest(TaskService taskService) {}
+ *     }
+ *   }
+ *  * </pre>
  */
 public class KadaiDependencyInjectionExtension
     implements ParameterResolver, TestInstancePostProcessor {

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiDependencyInjectionExtension.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiDependencyInjectionExtension.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.platform.commons.JUnitException;
 
+/**
+ * JUnit-Extension for injecting Kadai components via {@linkplain KadaiInject @KadaiInject}.
+ */
 public class KadaiDependencyInjectionExtension
     implements ParameterResolver, TestInstancePostProcessor {
 

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiInitializationExtension.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/KadaiInitializationExtension.java
@@ -71,6 +71,10 @@ import org.junit.platform.commons.JUnitException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+/**
+ * JUnit-Extension for initializing and modifying the {@link KadaiConfiguration} in integration
+ * tests.
+ */
 public class KadaiInitializationExtension
     implements TestInstancePostProcessor, TestInstancePreDestroyCallback {
 

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/TestContainerExtension.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/extensions/TestContainerExtension.java
@@ -39,6 +39,9 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+/**
+ * JUnit-Extension for creating containerized databases.
+ */
 public class TestContainerExtension implements InvocationInterceptor {
 
   public static final String STORE_DATA_SOURCE = "datasource";

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/security/WithAccessId.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/security/WithAccessId.java
@@ -18,27 +18,74 @@
 
 package io.kadai.testapi.security;
 
+import io.kadai.user.api.models.User;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation allowing to declare the Jaas-Context on methods in Test-Classes.
+ *
+ * <p>This annotation requires the surrounding method or class to be extended with the
+ * JUnit-Extension {@link JaasExtension}.
+ *
+ * <p>Usage may look like:
+ * <pre>
+ *   {@code
+ *     @ExtendWith(JaasExtension.class)
+ *     class MyTestClass {
+ *       @Test
+ *       @WithAccessId(user = "foo")
+ *       void myTest() {}
+ *     }
+ *   }
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Repeatable(WithAccessId.WithAccessIds.class)
 public @interface WithAccessId {
 
+  /**
+   * Returns the {@linkplain User#getId() id} of the user for this context.
+   *
+   * @return the id of the user
+   */
   String user();
 
+  /**
+   * Returns the {@linkplain User#getGroups() groups} of the user for this context.
+   *
+   * <p>Defaults to none.
+   *
+   * @return the groups of the user
+   */
   String[] groups() default {};
 
+  /**
+   * Returns the {@linkplain User#getPermissions() permissions} of the user for this context.
+   *
+   * <p>Defaults to none.
+   *
+   * @return the permissions of the user
+   */
   String[] permissions() default {};
 
+  /**
+   * Annotation allowing to declare multiple {@link WithAccessId}, executing the annotated method
+   * for each provided {@link WithAccessId} separately.
+   */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @interface WithAccessIds {
 
+    /**
+     * Returns all {@link WithAccessId} to run the annotated method with.
+     *
+     * @return the array of all {@link WithAccessId}-Annotations
+     */
     WithAccessId[] value();
   }
 }


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes


<!-- end-of-pr-marker -->
