### PR TITLE
Closes #683 - Remove deprecated elements

### DIFF
--- a/history/kadai-simplehistory-rest-spring/src/test/resources/application.properties
+++ b/history/kadai-simplehistory-rest-spring/src/test/resources/application.properties
@@ -33,12 +33,12 @@ kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=memberUid
+kadai.ldap.groupsOfUser.name=memberUid
 kadai.ldap.permissionSearchBase=cn=groups
 kadai.ldap.permissionSearchFilterName=objectclass
 kadai.ldap.permissionSearchFilterValue=groupofuniquenames
 kadai.ldap.permissionNameAttribute=permission
-kadai.ldap.permissionsOfUser=uniquemember
+kadai.ldap.permissionsOfUser.name=uniquemember
 kadai.ldap.useDnForGroups=true
 # Embedded Spring LDAP server
 spring.ldap.embedded.base-dn=OU=Test,O=KADAI

--- a/lib/kadai-core/src/main/java/io/kadai/classification/api/models/Classification.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/api/models/Classification.java
@@ -142,19 +142,6 @@ public interface Classification extends ClassificationSummary {
   void setServiceLevel(String serviceLevel);
 
   /**
-   * Sets the value for the specified {@linkplain ClassificationCustomField
-   * ClassificationCustomField}.
-   *
-   * @param customField the {@linkplain ClassificationCustomField ClassificationCustomField}
-   *     identifies which custom attribute is to be set
-   * @param value the value of the {@linkplain ClassificationCustomField ClassificationCustomField}
-   *     to be set
-   * @deprecated Use {@linkplain #setCustomField(ClassificationCustomField, String)} instead
-   */
-  @Deprecated
-  void setCustomAttribute(ClassificationCustomField customField, String value);
-
-  /**
    * Sets the value for {@linkplain ClassificationCustomField}.
    *
    * @param customField identifies which {@linkplain ClassificationCustomField} is to be set

--- a/lib/kadai-core/src/main/java/io/kadai/classification/api/models/ClassificationSummary.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/api/models/ClassificationSummary.java
@@ -106,19 +106,6 @@ public interface ClassificationSummary {
 
   /**
    * Returns the value of the specified {@linkplain ClassificationCustomField
-   * ClassificationCustomField} of the Classification.
-   *
-   * @param customField identifies which {@linkplain ClassificationCustomField
-   *     ClassificationCustomField} is requested
-   * @return the value for the given {@linkplain ClassificationCustomField
-   *     ClassificationCustomField}
-   * @deprecated Use {@linkplain #getCustomField(ClassificationCustomField)} instead
-   */
-  @Deprecated
-  String getCustomAttribute(ClassificationCustomField customField);
-
-  /**
-   * Returns the value of the specified {@linkplain ClassificationCustomField
    * ClassificationCustomField} of the classification.
    *
    * @param customField identifies which {@linkplain ClassificationCustomField

--- a/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationImpl.java
@@ -98,12 +98,6 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
     this.description = description == null ? null : description.trim();
   }
 
-  @Deprecated
-  @Override
-  public void setCustomAttribute(ClassificationCustomField customField, String value) {
-    setCustomField(customField, value);
-  }
-
   @Override
   public void setCustomField(ClassificationCustomField customField, String value) {
     switch (customField) {

--- a/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
@@ -168,12 +168,6 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     this.priority = priority;
   }
 
-  @Deprecated
-  @Override
-  public String getCustomAttribute(ClassificationCustomField customField) {
-    return getCustomField(customField);
-  }
-
   @Override
   public String getCustomField(ClassificationCustomField customField) {
     switch (customField) {

--- a/lib/kadai-core/src/main/java/io/kadai/task/api/models/Task.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/api/models/Task.java
@@ -146,16 +146,6 @@ public interface Task extends TaskSummary {
   /**
    * Sets the value for the specified {@linkplain TaskCustomField customField}.
    *
-   * @param customField identifies which {@linkplain TaskCustomField customField} is to be set
-   * @param value the value of the {@linkplain TaskCustomField customField} to be set
-   * @deprecated Use {@linkplain #setCustomField(TaskCustomField, String)} instead
-   */
-  @Deprecated
-  void setCustomAttribute(TaskCustomField customField, String value);
-
-  /**
-   * Sets the value for the specified {@linkplain TaskCustomField customField}.
-   *
    * @param customField identifies which {@linkplain TaskCustomField customField} is to be set.
    * @param value the value of the {@linkplain TaskCustomField customField} to be set
    */

--- a/lib/kadai-core/src/main/java/io/kadai/task/api/models/TaskSummary.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/api/models/TaskSummary.java
@@ -312,16 +312,6 @@ public interface TaskSummary {
    * Returns the value of the specified {@linkplain TaskCustomField} of the {@linkplain Task}.
    *
    * @param customField identifies which {@linkplain TaskCustomField} is requested
-   * @return the value for the given customField
-   * @deprecated Use {@linkplain #getCustomField(TaskCustomField)} instead
-   */
-  @Deprecated
-  String getCustomAttribute(TaskCustomField customField);
-
-  /**
-   * Returns the value of the specified {@linkplain TaskCustomField} of the {@linkplain Task}.
-   *
-   * @param customField identifies which {@linkplain TaskCustomField} is requested
    * @return the value for the given {@linkplain TaskCustomField}
    */
   String getCustomField(TaskCustomField customField);

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
@@ -128,12 +128,6 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     this.callbackInfo = callbackInfo;
   }
 
-  @Deprecated
-  @Override
-  public void setCustomAttribute(TaskCustomField customField, String value) {
-    setCustomField(customField, value);
-  }
-
   @Override
   public void setCustomField(TaskCustomField customField, String value) {
     switch (customField) {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskSummaryImpl.java
@@ -446,12 +446,6 @@ public class TaskSummaryImpl implements TaskSummary {
     isReopened = reopened;
   }
 
-  @Deprecated
-  @Override
-  public String getCustomAttribute(TaskCustomField customField) {
-    return getCustomField(customField);
-  }
-
   @Override
   public String getCustomField(TaskCustomField customField) {
 

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/api/models/Workbasket.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/api/models/Workbasket.java
@@ -47,16 +47,6 @@ public interface Workbasket extends WorkbasketSummary {
   void setType(WorkbasketType type);
 
   /**
-   * Sets the value of the specified {@linkplain WorkbasketCustomField}.
-   *
-   * @param customField identifies which {@linkplain WorkbasketCustomField} is to be set
-   * @param value the value of the {@linkplain WorkbasketCustomField} to be set
-   * @deprecated Use {@linkplain #setCustomField(WorkbasketCustomField, String)} instead
-   */
-  @Deprecated
-  void setCustomAttribute(WorkbasketCustomField customField, String value);
-
-  /**
    * Sets the value for the specified {@linkplain WorkbasketCustomField}.
    *
    * @param customField identifies which {@linkplain WorkbasketCustomField} is to be set.

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/api/models/WorkbasketSummary.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/api/models/WorkbasketSummary.java
@@ -80,17 +80,6 @@ public interface WorkbasketSummary {
    * Returns the value of the specified {@linkplain WorkbasketCustomField} of the {@linkplain
    * Workbasket}.
    *
-   * @param customField identifies which {@linkplain WorkbasketCustomField} is requested
-   * @return the value for the given {@linkplain WorkbasketCustomField}
-   * @deprecated Use {@linkplain #getCustomField(WorkbasketCustomField)} instead
-   */
-  @Deprecated
-  String getCustomAttribute(WorkbasketCustomField customField);
-
-  /**
-   * Returns the value of the specified {@linkplain WorkbasketCustomField} of the {@linkplain
-   * Workbasket}.
-   *
    * @param customField identifies which the value of the specified {@linkplain
    *     WorkbasketCustomField} of the {@linkplain Workbasket} is requested
    * @return the value for the given the value of the specified {@linkplain WorkbasketCustomField}

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketImpl.java
@@ -41,12 +41,6 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
     this.key = key == null ? null : key.trim();
   }
 
-  @Deprecated
-  @Override
-  public void setCustomAttribute(WorkbasketCustomField customField, String value) {
-    setCustomField(customField, value);
-  }
-
   @Override
   public void setCustomField(WorkbasketCustomField customField, String value) {
     switch (customField) {

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -134,12 +134,6 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
     this.type = type;
   }
 
-  @Deprecated
-  @Override
-  public String getCustomAttribute(WorkbasketCustomField customField) {
-    return getCustomField(customField);
-  }
-
   @Override
   public String getCustomField(WorkbasketCustomField customField) {
     switch (customField) {

--- a/rest/kadai-rest-spring-example-boot/src/main/resources/application-db2.properties
+++ b/rest/kadai-rest-spring-example-boot/src/main/resources/application-db2.properties
@@ -72,7 +72,7 @@ kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=memberUid
+kadai.ldap.groupsOfUser.name=memberUid
 # Embedded Spring LDAP server
 spring.ldap.embedded.base-dn=OU=Test,O=KADAI
 spring.ldap.embedded.credential.username=uid=admin

--- a/rest/kadai-rest-spring-example-boot/src/main/resources/application-postgres.properties
+++ b/rest/kadai-rest-spring-example-boot/src/main/resources/application-postgres.properties
@@ -56,7 +56,7 @@ kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=memberUid
+kadai.ldap.groupsOfUser.name=memberUid
 ####### JobScheduler cron expression that specifies when the JobSchedler runs
 kadai.jobscheduler.async.cron=0 * * * * *
 ####### cache static resources properties

--- a/rest/kadai-rest-spring-example-boot/src/main/resources/application.properties
+++ b/rest/kadai-rest-spring-example-boot/src/main/resources/application.properties
@@ -75,12 +75,12 @@ kadai.ldap.groupSearchFilterValue=groupofuniquenames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=uniquemember
+kadai.ldap.groupsOfUser.name=uniquemember
 kadai.ldap.permissionSearchBase=
 kadai.ldap.permissionSearchFilterName=objectclass
 kadai.ldap.permissionSearchFilterValue=groupofuniquenames
 kadai.ldap.permissionNameAttribute=permission
-kadai.ldap.permissionsOfUser=uniquemember
+kadai.ldap.permissionsOfUser.name=uniquemember
 kadai.ldap.useDnForGroups=true
 # Embedded Spring LDAP server
 spring.ldap.embedded.base-dn=OU=Test,O=KADAI

--- a/rest/kadai-rest-spring-example-common/src/test/resources/application-emptyPermissionAttributes.properties
+++ b/rest/kadai-rest-spring-example-common/src/test/resources/application-emptyPermissionAttributes.properties
@@ -34,7 +34,7 @@ kadai.ldap.groupSearchBase=cn=groups
 kadai.ldap.groupSearchFilterName=objectclass
 kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
-kadai.ldap.groupsOfUser=uniquemember
+kadai.ldap.groupsOfUser.name=uniquemember
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
 kadai.ldap.userMemberOfPermissionAttribute=
@@ -42,7 +42,7 @@ kadai.ldap.permissionSearchBase=
 kadai.ldap.permissionSearchFilterName=
 kadai.ldap.permissionSearchFilterValue=
 kadai.ldap.permissionNameAttribute=
-kadai.ldap.permissionsOfUser=
+kadai.ldap.permissionsOfUser.name=
 kadai.ldap.useDnForGroups=true
 kadai.ldap.userPermissionsAttribute=
 # Embedded Spring LDAP server

--- a/rest/kadai-rest-spring-example-common/src/test/resources/application.properties
+++ b/rest/kadai-rest-spring-example-common/src/test/resources/application.properties
@@ -34,7 +34,7 @@ kadai.ldap.groupSearchBase=cn=groups
 kadai.ldap.groupSearchFilterName=objectclass
 kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
-kadai.ldap.groupsOfUser=uniquemember
+kadai.ldap.groupsOfUser.name=uniquemember
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
 kadai.ldap.userMemberOfPermissionAttribute=memberOf
@@ -42,7 +42,7 @@ kadai.ldap.permissionSearchBase=
 kadai.ldap.permissionSearchFilterName=objectclass
 kadai.ldap.permissionSearchFilterValue=groupofuniquenames
 kadai.ldap.permissionNameAttribute=permission
-kadai.ldap.permissionsOfUser=uniquemember
+kadai.ldap.permissionsOfUser.name=uniquemember
 kadai.ldap.useDnForGroups=true
 kadai.ldap.userPermissionsAttribute=userPerm
 # Embedded Spring LDAP server

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
@@ -858,28 +858,7 @@ public class LdapClient {
   }
 
   List<LdapSettings> checkForMissingConfigurations() {
-    return Arrays.stream(LdapSettings.values())
-        // optional settings
-        .filter(not(LdapSettings.KADAI_LDAP_MAX_NUMBER_OF_RETURNED_ACCESS_IDS::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_MIN_SEARCH_FOR_LENGTH::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_EMAIL_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_PHONE_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_MOBILE_PHONE_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_1_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_2_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_3_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_4_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_GROUPS_OF_USER_NAME::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_GROUPS_OF_USER_TYPE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_NAME::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_TYPE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_ID_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_SEARCH_BASE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_SEARCH_FILTER_NAME::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_SEARCH_FILTER_VALUE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_NAME_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_USER_PERMISSIONS_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_GROUP_ID_ATTRIBUTE::equals))
+    return Arrays.stream(LdapSettings.REQUIRED_SETTINGS)
         .filter(p -> p.getValueFromEnv(env) == null)
         .toList();
   }

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
@@ -18,8 +18,6 @@
 
 package io.kadai.common.rest.ldap;
 
-import static java.util.function.Predicate.not;
-
 import io.kadai.KadaiConfiguration;
 import io.kadai.common.api.KadaiRole;
 import io.kadai.common.api.exceptions.InvalidArgumentException;

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapClient.java
@@ -716,11 +716,7 @@ public class LdapClient {
   }
 
   public String getGroupsOfUserName() {
-    String groupsOfUser = LdapSettings.KADAI_LDAP_GROUPS_OF_USER_NAME.getValueFromEnv(env);
-    if (groupsOfUser == null || groupsOfUser.isEmpty()) {
-      groupsOfUser = LdapSettings.KADAI_LDAP_GROUPS_OF_USER.getValueFromEnv(env);
-    }
-    return groupsOfUser;
+    return LdapSettings.KADAI_LDAP_GROUPS_OF_USER_NAME.getValueFromEnv(env);
   }
 
   public String getGroupsOfUserType() {
@@ -728,12 +724,7 @@ public class LdapClient {
   }
 
   public String getPermissionsOfUserName() {
-    String permissionsOfUser =
-        LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_NAME.getValueFromEnv(env);
-    if (permissionsOfUser == null || permissionsOfUser.isEmpty()) {
-      permissionsOfUser = LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER.getValueFromEnv(env);
-    }
-    return permissionsOfUser;
+    return LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_NAME.getValueFromEnv(env);
   }
 
   public String getPermissionsOfUserType() {
@@ -878,10 +869,8 @@ public class LdapClient {
         .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_2_ATTRIBUTE::equals))
         .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_3_ATTRIBUTE::equals))
         .filter(not(LdapSettings.KADAI_LDAP_USER_ORG_LEVEL_4_ATTRIBUTE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_GROUPS_OF_USER::equals))
         .filter(not(LdapSettings.KADAI_LDAP_GROUPS_OF_USER_NAME::equals))
         .filter(not(LdapSettings.KADAI_LDAP_GROUPS_OF_USER_TYPE::equals))
-        .filter(not(LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER::equals))
         .filter(not(LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_NAME::equals))
         .filter(not(LdapSettings.KADAI_LDAP_PERMISSIONS_OF_USER_TYPE::equals))
         .filter(not(LdapSettings.KADAI_LDAP_PERMISSION_ID_ATTRIBUTE::equals))

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapSettings.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/ldap/LdapSettings.java
@@ -18,11 +18,12 @@
 
 package io.kadai.common.rest.ldap;
 
+import static java.util.function.Predicate.not;
+
+import java.util.Arrays;
 import org.springframework.core.env.Environment;
 
-/**
- * All possible settings for LDAP.
- */
+/** All possible settings for LDAP. */
 enum LdapSettings {
   KADAI_LDAP_USER_SEARCH_BASE("kadai.ldap.userSearchBase"),
   KADAI_LDAP_USER_SEARCH_FILTER_NAME("kadai.ldap.userSearchFilterName"),
@@ -53,18 +54,57 @@ enum LdapSettings {
   KADAI_LDAP_GROUP_ID_ATTRIBUTE("kadai.ldap.groupIdAttribute"),
   KADAI_LDAP_MIN_SEARCH_FOR_LENGTH("kadai.ldap.minSearchForLength"),
   KADAI_LDAP_MAX_NUMBER_OF_RETURNED_ACCESS_IDS("kadai.ldap.maxNumberOfReturnedAccessIds"),
-  KADAI_LDAP_GROUPS_OF_USER("kadai.ldap.groupsOfUser"),
   KADAI_LDAP_GROUPS_OF_USER_NAME("kadai.ldap.groupsOfUser.name"),
   KADAI_LDAP_GROUPS_OF_USER_TYPE("kadai.ldap.groupsOfUser.type"),
-  KADAI_LDAP_PERMISSIONS_OF_USER("kadai.ldap.permissionsOfUser"),
   KADAI_LDAP_PERMISSIONS_OF_USER_NAME("kadai.ldap.permissionsOfUser.name"),
   KADAI_LDAP_PERMISSIONS_OF_USER_TYPE("kadai.ldap.permissionsOfUser.type"),
   KADAI_LDAP_USE_DN_FOR_GROUPS("kadai.ldap.useDnForGroups");
+
+  public static final LdapSettings[] OPTIONAL_SETTINGS = {
+    KADAI_LDAP_MAX_NUMBER_OF_RETURNED_ACCESS_IDS,
+    KADAI_LDAP_MIN_SEARCH_FOR_LENGTH,
+    KADAI_LDAP_USER_EMAIL_ATTRIBUTE,
+    KADAI_LDAP_USER_PHONE_ATTRIBUTE,
+    KADAI_LDAP_USER_MOBILE_PHONE_ATTRIBUTE,
+    KADAI_LDAP_USER_ORG_LEVEL_1_ATTRIBUTE,
+    KADAI_LDAP_USER_ORG_LEVEL_2_ATTRIBUTE,
+    KADAI_LDAP_USER_ORG_LEVEL_3_ATTRIBUTE,
+    KADAI_LDAP_USER_ORG_LEVEL_4_ATTRIBUTE,
+    KADAI_LDAP_GROUPS_OF_USER_NAME,
+    KADAI_LDAP_GROUPS_OF_USER_TYPE,
+    KADAI_LDAP_PERMISSIONS_OF_USER_NAME,
+    KADAI_LDAP_PERMISSIONS_OF_USER_TYPE,
+    KADAI_LDAP_PERMISSION_ID_ATTRIBUTE,
+    KADAI_LDAP_PERMISSION_SEARCH_BASE,
+    KADAI_LDAP_PERMISSION_SEARCH_FILTER_NAME,
+    KADAI_LDAP_PERMISSION_SEARCH_FILTER_VALUE,
+    KADAI_LDAP_PERMISSION_NAME_ATTRIBUTE,
+    KADAI_LDAP_USER_PERMISSIONS_ATTRIBUTE,
+    KADAI_LDAP_GROUP_ID_ATTRIBUTE
+  };
+
+  public static final LdapSettings[] REQUIRED_SETTINGS =
+      Arrays.stream(values())
+          .filter(not(LdapSettings::isOptional))
+          .toList()
+          .toArray(new LdapSettings[0]);
 
   private final String key;
 
   LdapSettings(String key) {
     this.key = key;
+  }
+
+  public boolean in(LdapSettings... states) {
+    return Arrays.asList(states).contains(this);
+  }
+
+  public boolean isOptional() {
+    return in(OPTIONAL_SETTINGS);
+  }
+
+  public boolean isRequired() {
+    return in(REQUIRED_SETTINGS);
   }
 
   String getKey() {

--- a/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ldap/LdapClientTest.java
+++ b/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ldap/LdapClientTest.java
@@ -247,9 +247,7 @@ class LdapClientTest {
 
   @Test
   void testLdap_checkForMissingConfigurations() {
-    final int optionalCount = 22;
-    assertThat(cut.checkForMissingConfigurations())
-        .hasSize(LdapSettings.values().length - optionalCount);
+    assertThat(cut.checkForMissingConfigurations()).hasSize(LdapSettings.REQUIRED_SETTINGS.length);
   }
 
   @Test
@@ -269,7 +267,7 @@ class LdapClientTest {
               {"kadai.ldap.baseDn", "o=KadaiTest"},
               {"kadai.ldap.userSearchBase", "ou=people"},
               {"kadai.ldap.userSearchFilterName", "objectclass"},
-              {"kadai.ldap.groupsOfUser", "memberUid"},
+              {"kadai.ldap.groupsOfUser.name", "memberUid"},
               {"kadai.ldap.groupNameAttribute", "cn"},
               {"kadai.ldap.userPermissionsAttribute", "permission"},
               {"kadai.ldap.groupSearchFilterValue", "groupOfUniqueNames"},
@@ -288,7 +286,7 @@ class LdapClientTest {
               {"kadai.ldap.userOrglevel2Attribute", "orgLevel2"},
               {"kadai.ldap.userOrglevel3Attribute", "orgLevel3"},
               {"kadai.ldap.userOrglevel4Attribute", "orgLevel4"},
-              {"kadai.ldap.permissionsOfUser", "memberUid"},
+              {"kadai.ldap.permissionsOfUser.name", "memberUid"},
               {"kadai.ldap.permissionNameAttribute", "permission"},
               {"kadai.ldap.permissionSearchFilterValue", "groupOfUniqueNames"},
               {"kadai.ldap.permissionSearchFilterName", "objectclass"},

--- a/rest/kadai-rest-spring/src/test/resources/application.properties
+++ b/rest/kadai-rest-spring/src/test/resources/application.properties
@@ -35,13 +35,13 @@ kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=uniquemember
+kadai.ldap.groupsOfUser.name=uniquemember
 kadai.ldap.groupsOfUser.type=
 kadai.ldap.permissionSearchBase=
 kadai.ldap.permissionSearchFilterName=objectclass
 kadai.ldap.permissionSearchFilterValue=groupofuniquenames
 kadai.ldap.permissionNameAttribute=permission
-kadai.ldap.permissionsOfUser=uniquemember
+kadai.ldap.permissionsOfUser.name=uniquemember
 kadai.ldap.useDnForGroups=true
 # Embedded Spring LDAP server
 spring.ldap.embedded.base-dn=OU=Test,O=KADAI

--- a/routing/kadai-routing-rest/src/test/resources/application.properties
+++ b/routing/kadai-routing-rest/src/test/resources/application.properties
@@ -37,12 +37,12 @@ kadai.ldap.groupSearchFilterValue=groupOfUniqueNames
 kadai.ldap.groupNameAttribute=cn
 kadai.ldap.minSearchForLength=3
 kadai.ldap.maxNumberOfReturnedAccessIds=50
-kadai.ldap.groupsOfUser=uniquemember
+kadai.ldap.groupsOfUser.name=uniquemember
 kadai.ldap.permissionSearchBase=
 kadai.ldap.permissionSearchFilterName=objectclass
 kadai.ldap.permissionSearchFilterValue=groupofuniquenames
 kadai.ldap.permissionNameAttribute=permission
-kadai.ldap.permissionsOfUser=uniquemember
+kadai.ldap.permissionsOfUser.name=uniquemember
 kadai.ldap.useDnForGroups=true
 # Embedded Spring LDAP server
 spring.ldap.embedded.base-dn=OU=Test,O=KADAI


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes
- Removed deprecated Entity::setCustomAttribute & EntitySummary::getCustomAttribute with Entity in [Workbasket, Task, Classification]. 
Use get/setCustomField instead.

- Removed deprecated LDAP-Properties kadai.ldap.groupsOfUser & kadai.ldap.permissionsOfUser.
Use kadai.ldap.groupsOfUser.name & kadai.ldap.permissionsOfUser.name instead.

<!-- end-of-pr-marker -->
