### PR TITLE
Closes #786 - Simplify `ClassificationDefinitionController::mapChildrenToParentKeys`...

### DIFF
--- a/rest/kadai-rest-spring/src/main/java/io/kadai/classification/rest/ClassificationDefinitionController.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/classification/rest/ClassificationDefinitionController.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.MediaType;
@@ -153,7 +152,6 @@ public class ClassificationDefinitionController implements ClassificationDefinit
   private Map<Classification, String> mapChildrenToParentKeys(
       Collection<ClassificationDefinitionRepresentationModel> definitionList,
       Map<String, String> systemIds) {
-    Stream<ClassificationDefinitionRepresentationModel> definitionStream = definitionList.stream();
 
     Set<String> keysWithDomain =
         definitionList.stream()
@@ -163,12 +161,17 @@ public class ClassificationDefinitionController implements ClassificationDefinit
 
     Map<String, String> classificationIdToKey =
         definitionList.stream()
+            .filter(
+                def ->
+                    def.getClassification().getClassificationId() != null
+                        && def.getClassification().getKey() != null)
             .collect(
                 Collectors.toMap(
                     def -> def.getClassification().getClassificationId(),
-                    def -> def.getClassification().getKey()));
+                    def -> def.getClassification().getKey(),
+                    (existing, replacement) -> existing));
 
-    definitionStream
+    definitionList.stream()
         .map(ClassificationDefinitionRepresentationModel::getClassification)
         .map(this::normalizeNullValues)
         .filter(cl -> !cl.getParentId().isEmpty() && cl.getParentKey().isEmpty())

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/classification/rest/ClassificationDefinitionController.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/classification/rest/ClassificationDefinitionController.java
@@ -200,11 +200,11 @@ public class ClassificationDefinitionController implements ClassificationDefinit
 
   Boolean hasResolvableParent(
       ClassificationRepresentationModel cl,
-      Set<String> newKeysWithDomain,
+      Set<String> keysWithDomain,
       Map<String, String> systemIds) {
     String parentKeyAndDomain = cl.getParentKey() + "|" + cl.getDomain();
     return !cl.getParentKey().isEmpty()
-        && (newKeysWithDomain.contains(parentKeyAndDomain)
+        && (keysWithDomain.contains(parentKeyAndDomain)
             || systemIds.containsKey(parentKeyAndDomain));
   }
 


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes


<!-- end-of-pr-marker -->
