### PR TITLE
Closes #925 - Add retry-logic for `verify_docs_alive.sh`

### DIFF
--- a/ci/verify_docs_alive.sh
+++ b/ci/verify_docs_alive.sh
@@ -1,10 +1,29 @@
 #!/bin/bash
-set -e # fail fast
-set -x
-BASE_URL=https://kadai-io.azurewebsites.net/kadai
 
-test 200 -eq "$(curl -sw "%{http_code}" -o /dev/null "$BASE_URL/api-docs")"
-test 200 -eq "$(curl -sw "%{http_code}" -o /dev/null "$BASE_URL/swagger-ui/index.html")"
+set -e
+set -x
+
+BASE_URL=https://kadai-io.azurewebsites.net/kadai
+MAX_RETRIES=5
+RETRY_DELAY=10  # in seconds
+
+retry_curl() {
+  local url=$1
+  local retries=$MAX_RETRIES
+  while [ $retries -gt 0 ]; do
+    status_code=$(curl -sw "%{http_code}" -o /dev/null "$url")
+    if [ "$status_code" -eq 200 ]; then
+      return 0
+    fi
+    echo "Retrying... ($((MAX_RETRIES - retries + 1))/$MAX_RETRIES) - Received status code $status_code for $url"
+    retries=$((retries - 1))
+    sleep $RETRY_DELAY
+  done
+  return 1
+}
+
+retry_curl "$BASE_URL/api-docs"
+retry_curl "$BASE_URL/swagger-ui/index.html"
 for module in kadai-core kadai-spring; do
-  test 200 -eq "$(curl -sw "%{http_code}" -o /dev/null "$BASE_URL/docs/java/$module/index.html")"
+  retry_curl "$BASE_URL/docs/java/$module/index.html"
 done


### PR DESCRIPTION
For the rare case this ain't cutting it, we can still increase the timeout for curl.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes


<!-- end-of-pr-marker -->