### PR TITLE
Closes #954 - Fix querying actual max schema version

### DIFF
--- a/common/kadai-common-data/src/test/java/io/kadai/sampledata/SampleDataGeneratorTest.java
+++ b/common/kadai-common-data/src/test/java/io/kadai/sampledata/SampleDataGeneratorTest.java
@@ -18,27 +18,64 @@
 
 package io.kadai.sampledata;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.kadai.common.internal.configuration.DbSchemaCreator;
+import io.kadai.common.internal.util.ComparableVersion;
+import java.sql.Connection;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
+import org.apache.ibatis.jdbc.SqlRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Test SampleDataGenerator. */
 class SampleDataGeneratorTest {
 
+  private PooledDataSource pooledDataSource;
+
   private static final String JDBC_URL =
       "jdbc:h2:mem:kadai;NON_KEYWORDS=KEY,VALUE;"
           + "IGNORECASE=TRUE;LOCK_MODE=0;INIT=CREATE SCHEMA IF NOT EXISTS KADAI";
 
+  @BeforeEach
+  void setUp() {
+    this.pooledDataSource = new PooledDataSource("org.h2.Driver", JDBC_URL, "sa", "sa");
+  }
+
+  @AfterEach
+  void tearDown() {
+    pooledDataSource.forceCloseAll();
+  }
+
   @Test
-  void getScriptsValidSql() {
-    PooledDataSource pooledDataSource = new PooledDataSource("org.h2.Driver", JDBC_URL, "sa", "sa");
+  void should_generateSchemaAndSchemaData() {
     assertThatCode(() -> new DbSchemaCreator(pooledDataSource, "KADAI").run())
         .doesNotThrowAnyException();
     assertThatCode(() -> new SampleDataGenerator(pooledDataSource, "KADAI").generateSampleData())
         .doesNotThrowAnyException();
+  }
 
-    pooledDataSource.forceCloseAll();
+  @Test
+  void should_ReturnMaximalSchemaVersion() throws Exception {
+    final DbSchemaCreator schemaCreator = new DbSchemaCreator(pooledDataSource, "KADAI");
+    schemaCreator.run();
+
+    try (Connection connection = schemaCreator.getDataSource().getConnection()) {
+      connection.setSchema(schemaCreator.getSchemaName());
+
+      final SqlRunner runner = new SqlRunner(connection);
+      runner.run(
+          "INSERT INTO KADAI_SCHEMA_VERSION (ID, VERSION, CREATED) "
+              + "VALUES (nextval('KADAI_SCHEMA_VERSION_ID_SEQ'), '9.0.0', CURRENT_TIMESTAMP)");
+      runner.run(
+          "INSERT INTO KADAI_SCHEMA_VERSION (ID, VERSION, CREATED) "
+              + "VALUES (nextval('KADAI_SCHEMA_VERSION_ID_SEQ'), '42.0.0', CURRENT_TIMESTAMP)");
+
+      final ComparableVersion actual = schemaCreator.getActualMaxVersion(runner);
+
+      assertThat(actual).isEqualTo(ComparableVersion.of("42.0.0"));
+    }
   }
 }

--- a/common/kadai-common/src/main/java/io/kadai/common/internal/configuration/DbSchemaCreator.java
+++ b/common/kadai-common/src/main/java/io/kadai/common/internal/configuration/DbSchemaCreator.java
@@ -122,6 +122,19 @@ public class DbSchemaCreator {
     }
   }
 
+  /**
+   * Retrieves the maximum version from the KADAI_SCHEMA_VERSION table.
+   *
+   * <p>This method executes a SQL query to fetch all version entries from the
+   * KADAI_SCHEMA_VERSION table, converts them to ComparableVersion objects, and
+   * determines the maximum version. If no versions are found, an IllegalStateException
+   * is thrown.
+   *
+   * @param runner the SqlRunner instance used to execute the query
+   * @return the maximum version as a ComparableVersion object
+   * @throws SQLException if a database access error occurs
+   * @throws IllegalStateException if no version exists in the KADAI_SCHEMA_VERSION table
+   */
   public ComparableVersion getActualMaxVersion(SqlRunner runner) throws SQLException {
     String query = "select VERSION from KADAI_SCHEMA_VERSION";
     return runner.selectAll(query).stream()


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes


<!-- end-of-pr-marker -->
