### PR TITLE
KAD-1049-draft: add release-drafter config

### DIFF
--- a/release-drafter.yml
+++ b/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: "v$NEXT_PATCH_VERSION 🌟"
+tag-template: "v$NEXT_PATCH_VERSION"
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+
+  - title: "🛠 Maintenance"
+    labels:
+      - "chore"
+
+  - title: "🔒 Dependencies"
+    labels:
+      - "dependencies"
+
+change-template: |
+  - $TITLE @$AUTHOR (#$NUMBER)
+    $BODY
+
+no-changes-template: "- No user-facing changes in this release."
+
+template: |
+  ## 📦 Release Notes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$TAG
+
+autolabeler:
+  - label: "feature"
+    branch:
+      - "/^feat[/-]/"
+
+  - label: "fix"
+    branch:
+      - "/^fix[/-]/"
+
+  - label: "chore"
+    branch:
+      - "/^chore[/-]/"


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:

<!-- Use bullet points '-' for custom release-notes. Sub-Points are allowed if indented by two compared to parent -->

## Custom Release-Notes


<!-- end-of-pr-marker -->