### PR TITLE
Closes #1196 - Unify Persistence-Layer-Access to one DAO per Entity

### DIFF
--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapper.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapper.java
@@ -94,9 +94,18 @@ public interface UserMapper {
   @DeleteProvider(type = UserMapperSqlProvider.class, method = "delete")
   void delete(String id);
 
+  @DeleteProvider(type = UserMapperSqlProvider.class, method = "deleteAll")
+  void deleteAll();
+
   @DeleteProvider(type = UserMapperSqlProvider.class, method = "deleteGroups")
   void deleteGroups(String id);
 
+  @DeleteProvider(type = UserMapperSqlProvider.class, method = "deleteAllGroups")
+  void deleteAllGroups();
+
   @DeleteProvider(type = UserMapperSqlProvider.class, method = "deletePermissions")
   void deletePermissions(String id);
+
+  @DeleteProvider(type = UserMapperSqlProvider.class, method = "deleteAllPermissions")
+  void deleteAllPermissions();
 }

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapperSqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapperSqlProvider.java
@@ -22,6 +22,7 @@ import static io.kadai.common.internal.util.SqlProviderUtil.CLOSING_SCRIPT_TAG;
 import static io.kadai.common.internal.util.SqlProviderUtil.DB2_WITH_UR;
 import static io.kadai.common.internal.util.SqlProviderUtil.OPENING_SCRIPT_TAG;
 
+@SuppressWarnings("unused")
 public class UserMapperSqlProvider {
 
   private static final String USER_INFO_COLUMNS =
@@ -104,11 +105,23 @@ public class UserMapperSqlProvider {
     return "DELETE FROM USER_INFO WHERE USER_ID = #{id} ";
   }
 
+  public static String deleteAll() {
+    return "DELETE FROM USER_INFO ";
+  }
+
   public static String deleteGroups() {
     return "DELETE FROM GROUP_INFO WHERE USER_ID = #{id} ";
   }
 
+  public static String deleteAllGroups() {
+    return "DELETE FROM GROUP_INFO ";
+  }
+
   public static String deletePermissions() {
     return "DELETE FROM PERMISSION_INFO WHERE USER_ID = #{id} ";
+  }
+
+  public static String deleteAllPermissions() {
+    return "DELETE FROM PERMISSION_INFO ";
   }
 }

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
@@ -208,6 +208,16 @@ public class UserServiceImpl implements UserService {
     return Collections.emptySet();
   }
 
+  public void deleteAllUsersGroupsPermissions() throws NotAuthorizedException {
+    internalKadaiEngine.getEngine().checkRoleMembership(KadaiRole.BUSINESS_ADMIN, KadaiRole.ADMIN);
+    internalKadaiEngine.executeInDatabaseConnection(
+        () -> {
+          userMapper.deleteAll();
+          userMapper.deleteAllGroups();
+          userMapper.deleteAllPermissions();
+        });
+  }
+
   private void insertIntoDatabase(User userToCreate) throws UserAlreadyExistException {
     try {
       internalKadaiEngine.openConnection();


### PR DESCRIPTION
Did not adjust [`TaskUpdatePriorityBatchStatement`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/task/internal/jobs/helper/TaskUpdatePriorityBatchStatement.java#L35) because MyBatis has no configuration-driven way to execute batch-statements.

I did not want to use dynamic `<foreach>...` for the task-priority updates as this would be much more expensive than manual batching.
As caches won't be used anyways  and the importance of this ticket is degarded, we're fine with the little scattering of the data-access-layer.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: