### PR TITLE
Closes #1195 - Fix copy constructors to ensure value-based copy

### DIFF
--- a/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
@@ -66,6 +66,7 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     custom6 = copyFrom.custom6;
     custom7 = copyFrom.custom7;
     custom8 = copyFrom.custom8;
+    key = copyFrom.key;
   }
 
   @Override

--- a/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/classification/internal/models/ClassificationSummaryImpl.java
@@ -52,6 +52,7 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     applicationEntryPoint = copyFrom.applicationEntryPoint;
     category = copyFrom.category;
     domain = copyFrom.domain;
+    key = copyFrom.key;
     name = copyFrom.name;
     parentId = copyFrom.parentId;
     parentKey = copyFrom.parentKey;
@@ -66,7 +67,6 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     custom6 = copyFrom.custom6;
     custom7 = copyFrom.custom7;
     custom8 = copyFrom.custom8;
-    key = copyFrom.key;
   }
 
   @Override

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/AttachmentSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/AttachmentSummaryImpl.java
@@ -41,12 +41,12 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
   AttachmentSummaryImpl() {}
 
   protected AttachmentSummaryImpl(AttachmentSummaryImpl copyFrom) {
-    created = copyFrom.created;
-    modified = copyFrom.modified;
-    classificationSummary = copyFrom.classificationSummary;
-    objectReference = copyFrom.objectReference;
-    channel = copyFrom.channel;
-    received = copyFrom.received;
+    this.created = copyFrom.created != null ? Instant.from(copyFrom.created) : null;
+    this.modified = copyFrom.modified != null ? Instant.from(copyFrom.modified) : null;
+    this.classificationSummary = copyFrom.classificationSummary;
+    this.objectReference = copyFrom.objectReference;
+    this.channel = copyFrom.channel;
+    this.received = copyFrom.received != null ? Instant.from(copyFrom.received) : null;
   }
 
   @Override

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/ObjectReferenceImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/ObjectReferenceImpl.java
@@ -44,11 +44,11 @@ public class ObjectReferenceImpl implements ObjectReference {
   }
 
   private ObjectReferenceImpl(ObjectReferenceImpl copyFrom) {
-    company = copyFrom.company;
-    system = copyFrom.system;
-    systemInstance = copyFrom.systemInstance;
-    type = copyFrom.type;
-    value = copyFrom.value;
+    this.company = copyFrom.company;
+    this.system = copyFrom.system;
+    this.systemInstance = copyFrom.systemInstance;
+    this.type = copyFrom.type;
+    this.value = copyFrom.value;
   }
 
   public static void validate(ObjectReference objectReference, String objRefType, String objName)

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskCommentImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskCommentImpl.java
@@ -36,11 +36,12 @@ public class TaskCommentImpl implements TaskComment {
   public TaskCommentImpl() {}
 
   public TaskCommentImpl(TaskCommentImpl copyFrom) {
-    taskId = copyFrom.taskId;
-    textField = copyFrom.textField;
-    creator = copyFrom.creator;
-    created = copyFrom.created;
-    modified = copyFrom.modified;
+    this.taskId = copyFrom.taskId;
+    this.textField = copyFrom.textField;
+    this.creator = copyFrom.creator;
+    this.creatorFullName = copyFrom.creatorFullName;
+    this.created = copyFrom.created != null ? Instant.from(copyFrom.created) : null;
+    this.modified = copyFrom.modified != null ? Instant.from(copyFrom.modified) : null;
   }
 
   @Override

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
@@ -55,6 +55,7 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
             .stream()
             .map(Attachment::copy)
             .collect(Collectors.toList());
+    this.groupByCount = copyFrom.groupByCount;
   }
 
   public Map<String, String> getCustomAttributes() {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskImpl.java
@@ -48,11 +48,13 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
 
   private TaskImpl(TaskImpl copyFrom) {
     super(copyFrom);
-    customAttributes = new HashMap<>(copyFrom.customAttributes);
-    callbackInfo = new HashMap<>(copyFrom.callbackInfo);
-    callbackState = copyFrom.callbackState;
-    attachments = copyFrom.attachments.stream().map(Attachment::copy).collect(Collectors.toList());
-    groupByCount = copyFrom.groupByCount;
+    this.customAttributes = new HashMap<>(copyFrom.customAttributes);
+    this.callbackInfo = new HashMap<>(copyFrom.callbackInfo);
+    this.callbackState = copyFrom.callbackState;
+    this.attachments = copyFrom.attachments
+            .stream()
+            .map(Attachment::copy)
+            .collect(Collectors.toList());
   }
 
   public Map<String, String> getCustomAttributes() {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/models/TaskSummaryImpl.java
@@ -99,13 +99,13 @@ public class TaskSummaryImpl implements TaskSummary {
   public TaskSummaryImpl() {}
 
   protected TaskSummaryImpl(TaskSummaryImpl copyFrom) {
-    received = copyFrom.received;
-    created = copyFrom.created;
-    claimed = copyFrom.claimed;
-    completed = copyFrom.completed;
-    modified = copyFrom.modified;
-    planned = copyFrom.planned;
-    due = copyFrom.due;
+    received = copyFrom.received != null ? Instant.from(copyFrom.received) : null;
+    created = copyFrom.created != null ? Instant.from(copyFrom.created) : null;
+    claimed = copyFrom.claimed != null ? Instant.from(copyFrom.claimed) : null;
+    completed = copyFrom.completed != null ? Instant.from(copyFrom.completed) : null;
+    modified = copyFrom.modified != null ? Instant.from(copyFrom.modified) : null;
+    planned = copyFrom.planned != null ? Instant.from(copyFrom.planned) : null;
+    due = copyFrom.due != null ? Instant.from(copyFrom.due) : null;
     name = copyFrom.name;
     creator = copyFrom.creator;
     note = copyFrom.note;

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/models/UserSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/models/UserSummaryImpl.java
@@ -20,6 +20,7 @@ package io.kadai.user.internal.models;
 
 import io.kadai.user.api.models.UserSummary;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -46,9 +47,8 @@ public class UserSummaryImpl implements UserSummary {
   public UserSummaryImpl() {}
 
   protected UserSummaryImpl(UserSummaryImpl copyFrom) {
-    this.id = copyFrom.id;
-    this.groups = copyFrom.groups;
-    this.permissions = copyFrom.permissions;
+    this.groups = new HashSet<>(copyFrom.groups);
+    this.permissions = new HashSet<>(copyFrom.permissions);
     this.firstName = copyFrom.firstName;
     this.lastName = copyFrom.lastName;
     this.fullName = copyFrom.fullName;
@@ -60,7 +60,7 @@ public class UserSummaryImpl implements UserSummary {
     this.orgLevel3 = copyFrom.orgLevel3;
     this.orgLevel2 = copyFrom.orgLevel2;
     this.orgLevel1 = copyFrom.orgLevel1;
-    this.domains = copyFrom.domains;
+    this.domains = new HashSet<>(copyFrom.domains);
   }
 
   @Override

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketImpl.java
@@ -36,8 +36,8 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
 
   private WorkbasketImpl(WorkbasketImpl copyFrom, String key) {
     super(copyFrom);
-    created = copyFrom.created;
-    modified = copyFrom.modified;
+    this.created = copyFrom.created != null ? Instant.from(copyFrom.created) : null;
+    this.modified = copyFrom.modified != null ? Instant.from(copyFrom.modified) : null;
     this.key = key == null ? null : key.trim();
   }
 

--- a/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -51,6 +51,7 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
   public WorkbasketSummaryImpl() {}
 
   protected WorkbasketSummaryImpl(WorkbasketSummaryImpl copyFrom) {
+    key = copyFrom.key;
     name = copyFrom.name;
     description = copyFrom.description;
     owner = copyFrom.owner;


### PR DESCRIPTION
Closes #1195 

This PR fixes and standardizes several copy constructors as part of #1195 
- Ensures fields are copied by value where needed.
- Leaves entity-type fields copied by reference, as confirmed in the issue discussion.
- Adds any missing fields that were previously not copied.

Updated classes
- `TaskImpl`, `TaskSummaryImpl`, `TaskCommentImpl`

- `AttachmentSummaryImpl`, `ObjectReferenceImpl`

- `WorkbasketImpl`, `WorkbasketSummaryImpl`

- `ClassificationSummaryImpl`

- `UserSummaryImpl`

Other classes like `UserImpl`, `WorkbasketAccessItemImpl`, and `ClassificationImpl` were reviewed but required no changes.
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: