### PR TITLE
Closes #1207 - Log and skip error-prone users when refreshing from ldap

### DIFF
--- a/rest/kadai-rest-spring/src/main/java/io/kadai/user/jobs/UserInfoRefreshJob.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/user/jobs/UserInfoRefreshJob.java
@@ -68,21 +68,14 @@ public class UserInfoRefreshJob extends AbstractKadaiJob {
   @Override
   protected void execute() {
     LOGGER.info("Running job to refresh all user info");
-
-    LdapClient ldapClient =
-        ApplicationContextProvider.getApplicationContext().getBean("ldapClient", LdapClient.class);
-
     try {
-
+      final LdapClient ldapClient =
+          ApplicationContextProvider.getApplicationContext()
+              .getBean("ldapClient", LdapClient.class);
       List<User> users = ldapClient.searchUsersInUserRole();
-      List<User> usersAfterProcessing =
-          users.stream().map(refreshUserPostprocessorManager::processUserAfterRefresh).toList();
-      addExistingConfigurationDataToUsers(usersAfterProcessing);
       clearExistingUsersAndGroupsAndPermissions();
-      insertNewUsers(usersAfterProcessing);
-
+      users.forEach(this::executeUser);
       LOGGER.info("Job to refresh all user info has finished.");
-
     } catch (Exception e) {
       throw new SystemException("Error while processing UserRefreshJob.", e);
     }
@@ -101,55 +94,56 @@ public class UserInfoRefreshJob extends AbstractKadaiJob {
     }
   }
 
-  private void insertNewUsers(List<User> users) {
-
-    users.forEach(
-        user -> {
-          try {
-            if (LOGGER.isDebugEnabled()) {
-              LOGGER.debug("Trying to insert user {}", user);
-            }
-            kadaiEngineImpl.getUserService().createUser(user);
-            if (LOGGER.isDebugEnabled()) {
-              LOGGER.debug("Successfully inserted user {}", user);
-            }
-          } catch (InvalidArgumentException
-              | NotAuthorizedException
-              | UserAlreadyExistException e) {
-            throw new SystemException("Caught Exception while trying to insert new User", e);
-          }
-        });
+  private void executeUser(User user) {
+    try {
+      final User userAfterProcessing =
+          refreshUserPostprocessorManager.processUserAfterRefresh(user);
+      addExistingConfigurationDataToUser(userAfterProcessing);
+      insertNewUser(userAfterProcessing);
+    } catch (Exception e) {
+      LOGGER.error("Failed refreshing user {}", user, e);
+    }
   }
 
-  private void addExistingConfigurationDataToUsers(List<User> users) {
+  private void insertNewUser(User user) {
+    try {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Trying to insert user {}", user);
+      }
+      kadaiEngineImpl.getUserService().createUser(user);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Successfully inserted user {}", user);
+      }
+    } catch (InvalidArgumentException | NotAuthorizedException | UserAlreadyExistException e) {
+      throw new SystemException("Caught Exception while trying to insert new User", e);
+    }
+  }
 
-    users.forEach(
-        user -> {
-          try {
+  private void addExistingConfigurationDataToUser(User user) {
+    try {
 
-            String userData = kadaiEngineImpl.getUserService().getUser(user.getId()).getData();
-            if (userData != null) {
-              if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Trying to set userData {} for user {}", userData, user);
-              }
-              user.setData(userData);
-              if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Successfully set userData {} for user {}", userData, user);
-              }
-            }
-          } catch (UserNotFoundException e) {
-            if (LOGGER.isDebugEnabled()) {
-              LOGGER.debug(
-                  String.format(
-                      "Failed to fetch configuration data for User "
-                          + "with ID '%s' because it doesn't exist",
-                      user.getId()));
-            }
-          } catch (InvalidArgumentException e) {
-            if (LOGGER.isDebugEnabled()) {
-              LOGGER.debug("Failed to fetch configuration data because userId was NULL or empty");
-            }
-          }
-        });
+      String userData = kadaiEngineImpl.getUserService().getUser(user.getId()).getData();
+      if (userData != null) {
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Trying to set userData {} for user {}", userData, user);
+        }
+        user.setData(userData);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Successfully set userData {} for user {}", userData, user);
+        }
+      }
+    } catch (UserNotFoundException e) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            String.format(
+                "Failed to fetch configuration data for User "
+                    + "with ID '%s' because it doesn't exist",
+                user.getId()));
+      }
+    } catch (InvalidArgumentException e) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Failed to fetch configuration data because userId was NULL or empty");
+      }
+    }
   }
 }

--- a/rest/kadai-rest-spring/src/test/java/io/kadai/user/jobs/UserInfoRefreshJobIntTest.java
+++ b/rest/kadai-rest-spring/src/test/java/io/kadai/user/jobs/UserInfoRefreshJobIntTest.java
@@ -20,6 +20,7 @@ package io.kadai.user.jobs;
 
 import static io.kadai.common.internal.util.CheckedFunction.rethrowing;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import io.kadai.common.api.KadaiEngine;
 import io.kadai.common.rest.ldap.LdapClient;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @KadaiSpringBootTest
 @ExtendWith(JaasExtension.class)
@@ -50,7 +52,7 @@ class UserInfoRefreshJobIntTest {
 
   KadaiEngine kadaiEngine;
   UserService userService;
-  LdapClient ldapClient;
+  @MockitoSpyBean LdapClient ldapClient;
 
   @Autowired
   public UserInfoRefreshJobIntTest(
@@ -64,7 +66,6 @@ class UserInfoRefreshJobIntTest {
   @WithAccessId(user = "businessadmin")
   @Order(1)
   void should_RefreshUserInfo_When_UserInfoRefreshJobIsExecuted() throws Exception {
-
     try (Connection connection = kadaiEngine.getConfiguration().getDataSource().getConnection()) {
 
       List<User> users = getUsers(connection);
@@ -97,9 +98,7 @@ class UserInfoRefreshJobIntTest {
 
         User ldapUser = ldapusers.get(i);
         List<String> ldapGroups =
-            ldapUser.getGroups().stream()
-                .sorted(Comparator.naturalOrder())
-                .toList();
+            ldapUser.getGroups().stream().sorted(Comparator.naturalOrder()).toList();
 
         // we know that our users from ldap have groups defined
         // so non should be empty
@@ -117,9 +116,7 @@ class UserInfoRefreshJobIntTest {
 
         User ldapUser = ldapusers.get(i);
         List<String> ldapPermissions =
-            ldapUser.getPermissions().stream()
-                .sorted(Comparator.naturalOrder())
-                .toList();
+            ldapUser.getPermissions().stream().sorted(Comparator.naturalOrder()).toList();
 
         assertThat(permissionIds)
             .hasSameSizeAs(ldapPermissions)
@@ -148,6 +145,32 @@ class UserInfoRefreshJobIntTest {
       rs.next();
       String updatedOrgLevel = rs.getString("ORG_LEVEL_1");
       assertThat(updatedOrgLevel).isEqualTo("FirstSecond");
+    }
+  }
+
+  @Test
+  @WithAccessId(user = "businessadmin")
+  @Order(3)
+  void should_RefreshUserInfoAndSkipErrorProneUsers_When_UserInfoRefreshJobIsExecuted()
+      throws Exception {
+
+    try (Connection connection = kadaiEngine.getConfiguration().getDataSource().getConnection()) {
+
+      List<User> users = getUsers(connection);
+      assertThat(users).hasSize(6);
+
+      // Incomplete user - supposed to fail in the Job
+      users.get(0).setId(null);
+      when(ldapClient.searchUsersInUserRole()).thenReturn(users);
+
+      UserInfoRefreshJob userInfoRefreshJob = new UserInfoRefreshJob(kadaiEngine);
+      userInfoRefreshJob.execute();
+
+      users = getUsers(connection);
+      List<User> ldapusers = ldapClient.searchUsersInUserRole();
+
+      assertThat(users).hasSize(ldapusers.size() - 1);
+      assertThat(users).hasSize(5);
     }
   }
 


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: