### PR TITLE
Closes #1401 - Add OpenEnergyBadges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,36 @@ Our focus is mainly directed to the backend, but we maintain a demo frontend in 
 
 For login choose username `teamlead-1` with password `teamlead-1`.
 
+# ⚡️OpenEnergyBadge
+
+KADAI is currently undergoing certification with the *Blauer Engel for Software*, an eco-label for resource- and energy-efficient software products. A central part of the certification is the definition of a standard usage scenario, which reflects typical user interactions.
+
+In our defined scenario, the following activities are performed:
+
+* Create a new task
+* Search for workbaskets with a specific permission (OPEN)
+* Open a workbasket 
+* Retrieve the first 50 tasks from a workbasket
+* Read a single task
+* Edit a task
+* Transfer a task to another workbasket
+* Claim a task  
+* Retrieve comments for a task
+* Add a new comment to a task
+* Delete a comment
+* Complete a task
+* Search for additional tasks with the same object reference
+
+Additionally, a single user performs the following activity:
+* Retrieve the task status report (monitoring)
+
+These badges show the energy cost for this scenario (done by 100 virtual users): 
+
+<img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=psu_energy_ac_mcp_machine" loading="lazy">
+
+         
+<img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=cpu_energy_rapl_msr_component" loading="lazy">
+
 # 📨Contact
 
 If you have any questions or ideas feel free to create an [issue](https://github.com/kadai-io/kadai/issues),
@@ -273,3 +303,5 @@ with the support of the open source community.
 ---
 [![envite consulting GmbH](docs/images/envite-black.png)](https://envite.de/)
 ---
+
+                       

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ For login choose username `teamlead-1` with password `teamlead-1`.
 
 # ⚡️OpenEnergyBadge
 
-KADAI is currently undergoing certification with the *Blauer Engel for Software*, an eco-label for resource- and energy-efficient software products awarded by the German Environment Agency (Umweltbundesamt). A central part of the certification is the definition of a standard usage scenario, which reflects typical user interactions.
+KADAI is currently undergoing certification with the [*Blauer Engel for Software*](https://www.blauer-engel.de/en/productworld/software), an eco-label for resource- and energy-efficient software products awarded by the [German Environment Agency (Umweltbundesamt)](https://www.umweltbundesamt.de/en). A central part of the certification is the definition of a standard usage scenario, which reflects typical user interactions.
+
 
 In our defined scenario, the following activities are performed:
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For login choose username `teamlead-1` with password `teamlead-1`.
 
 # ⚡️OpenEnergyBadge
 
-KADAI is currently undergoing certification with the *Blauer Engel for Software*, an eco-label for resource- and energy-efficient software products. A central part of the certification is the definition of a standard usage scenario, which reflects typical user interactions.
+KADAI is currently undergoing certification with the *Blauer Engel for Software*, an eco-label for resource- and energy-efficient software products awarded by the German Environment Agency (Umweltbundesamt). A central part of the certification is the definition of a standard usage scenario, which reflects typical user interactions.
 
 In our defined scenario, the following activities are performed:
 

--- a/README.md
+++ b/README.md
@@ -284,10 +284,18 @@ Additionally, a single user performs the following activity:
 
 These badges show the energy cost for this scenario (done by 100 virtual users): 
 
-<img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=psu_energy_ac_mcp_machine" loading="lazy">
+<a href="https://metrics.green-coding.io/stats.html?id=59ce2670-046e-4911-b1bc-a9f618616002">
+  <img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=psu_energy_ac_mcp_machine" 
+       alt="Machine Energy Badge" 
+       loading="lazy">
+</a>
 
-         
-<img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=cpu_energy_rapl_msr_component" loading="lazy">
+
+<a href="https://metrics.green-coding.io/stats.html?id=59ce2670-046e-4911-b1bc-a9f618616002">
+  <img src="https://api.green-coding.io/v1/badge/single/59ce2670-046e-4911-b1bc-a9f618616002?metric=cpu_energy_rapl_msr_component" 
+       alt="CPU Package Energy Badge" 
+       loading="lazy">
+</a>
 
 # 📨Contact
 


### PR DESCRIPTION
This PR adds OpenEnergyBadges to the projects README.md.

As part of the Blauer Engel certification, we measured KADAI’s standard usage scenario using GMT -> GMT provides verifiable, linkable badges for public measurements.

These badges are now embedded in the README to transparently show the energy footprint of KADAI under realistic load (100 virtual users).

* Increases transparency by directly showing resource-efficiency results in the README.
* Provides verifiable links to GMT public measurement reports.
* Demonstrates our commitment to sustainable software development.