### PR TITLE
Closes #1487 - Eco-CI integration for core build and test phases

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,8 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Build Backend"
         continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
@@ -94,6 +96,13 @@ jobs:
     name: Compile kadai-web
     runs-on: ubuntu-22.04
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Build Frontend"
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -132,8 +141,27 @@ jobs:
         run: |
           yarn lint
           yarn build:prod
+      - name: Eco CI Measurement of yarn build
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "compile_frontend: yarn build"
+        continue-on-error: true
       - name: Build maven artifact
         run: ./mvnw -B install -pl :kadai-web -am
+      - name: Eco CI Measurement of mvn :kadai-web
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "compile_frontend: mvn :kadai-web"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Upload kadai-web dist artifact
         uses: actions/upload-artifact@v4
         with:
@@ -151,6 +179,13 @@ jobs:
     name: Test kadai-web
     needs: [ compile_frontend ]
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Test Frontend"
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Enable Corepack
@@ -186,6 +221,19 @@ jobs:
       - name: Test
         working-directory: web
         run: yarn run test --coverageReporters text-summary
+      - name: Eco CI Measurement of web unit tests
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "test_frontend: web unit tests"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Cancel workflow
         if: failure()
         uses: andymckay/cancel-action@0.5
@@ -194,16 +242,13 @@ jobs:
     runs-on: ubuntu-22.04
     name: Test E2E
     needs: [ compile_frontend, compile_backend ]
-    permissions:
-      actions: read 
-      contents: read
-      issues: write
-      pull-requests: write
     steps:
       - name: Start Eco CI Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Test e2e"
         continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
@@ -335,6 +380,8 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Test Backend (H2)"
         continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
@@ -401,6 +448,13 @@ jobs:
         database:
           - DB2
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Test Backend (JDK21/DB2)"
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Set up JDK 21
@@ -426,6 +480,19 @@ jobs:
         run: ./mvnw -B test -pl :${{matrix.module}} -Dcheckstyle.skip -D"java.version=21"
         env:
           DB: ${{ matrix.database }}
+      - name: Eco CI Measurement of ${{ matrix.module }} (JDK21/DB2)
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "test_backend_21: ${{ matrix.module }} (DB2)"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Cancel workflow
         if: failure()
         uses: andymckay/cancel-action@0.5
@@ -492,6 +559,13 @@ jobs:
     env:
       GPG_TTY: $(tty)
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Release"
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
         with:
@@ -544,6 +618,19 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      - name: Eco CI Measurement of release deploy
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "release_artifacts: mvn deploy"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Cancel workflow
         if: failure()
         uses: andymckay/cancel-action@0.5
@@ -641,6 +728,13 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     needs: [ test_frontend, test_e2e, test_backend_17, test_backend_21 ]
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+          project: "KADAI"
+          tags: "CI/CD, Sonar"
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
         with:
@@ -675,6 +769,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+      - name: Eco CI Measurement of sonar verify
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "upload_to_sonar: mvn verify + sonar"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Cancel workflow
         if: failure()
         uses: andymckay/cancel-action@0.5

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -315,7 +315,7 @@ jobs:
         uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: display-results
-          pr-comment: true
+          pr-comment: false
           display-badge: true
         continue-on-error: true
       - name: Upload Cypress tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -194,11 +194,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: Test E2E
     needs: [ compile_frontend, compile_backend ]
-  permissions:
-    actions: read
-    contents: read
-    pull-requests: write
-    issues: write
+    permissions:
+      actions: read 
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Start Eco CI Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@v5

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,6 +37,11 @@ jobs:
     name: Compile all maven modules
     runs-on: ubuntu-22.04
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -55,6 +60,19 @@ jobs:
         run: ci/change_version.sh -m .
       - name: Compile & build
         run: ./mvnw -B install -DskipTests -Djacoco.skip
+      - name: Eco CI Measurement of mvn install
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "compile_backend: mvn install"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Populate cache
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
@@ -177,6 +195,11 @@ jobs:
     name: Test E2E
     needs: [ compile_frontend, compile_backend ]
     steps:
+      - name: Start Eco CI Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -232,6 +255,19 @@ jobs:
         run: |
           ../mvnw -B spring-boot:run -P history.plugin -f .. -pl :kadai-rest-spring-example-boot &> /dev/null &
           npx wait-port -t 30000 localhost:8080 && yarn run e2e-standalone --spec "cypress/e2e/monitor/**"
+      - name: Eco CI Measurement of cypress e2e
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "test_e2e: cypress"
+        continue-on-error: true
+      - name: Show Eco CI Result with pr comment
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          pr-comment: true
+          display-badge: true
+        continue-on-error: true
       - name: Upload Cypress tests
         if: failure()
         uses: actions/upload-artifact@v4
@@ -289,6 +325,12 @@ jobs:
           - module: kadai-rest-spring-example-boot
             database: DB2
     steps:
+      - name: Start Eco CI Measurement
+        if: matrix.database == 'H2'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: start-measurement
+        continue-on-error: true
       - name: Git checkout
         uses: actions/checkout@v5
       - name: Set up JDK ${{ env.JAVA_VERSION }}
@@ -314,6 +356,21 @@ jobs:
         run: ./mvnw -B verify -pl :${{matrix.module}} -Dcheckstyle.skip
         env:
           DB: ${{ matrix.database }}
+      - name: Eco CI Measurement of ${{ matrix.module }} (H2)
+        if: matrix.database == 'H2'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: get-measurement
+          label: "test_backend_17: ${{ matrix.module }} (H2)"
+        continue-on-error: true
+      - name: Show Eco CI Results
+        if: matrix.database == 'H2'
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
+        with:
+          task: display-results
+          display-badge: true
+          pr-comment: false
+        continue-on-error: true
       - name: Upload JaCoCo Report
         if: matrix.database == 'H2'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -311,7 +311,7 @@ jobs:
           task: get-measurement
           label: "test_e2e: cypress"
         continue-on-error: true
-      - name: Show Eco CI Result with pr comment
+      - name: Show Eco CI Results
         uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: display-results

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -194,6 +194,9 @@ jobs:
     runs-on: ubuntu-22.04
     name: Test E2E
     needs: [ compile_frontend, compile_backend ]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Start Eco CI Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@v5

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -194,9 +194,11 @@ jobs:
     runs-on: ubuntu-22.04
     name: Test E2E
     needs: [ compile_frontend, compile_backend ]
-    permissions:
-      contents: read
-      pull-requests: write
+  permissions:
+    actions: read
+    contents: read
+    pull-requests: write
+    issues: write
     steps:
       - name: Start Eco CI Measurement
         uses: green-coding-solutions/eco-ci-energy-estimation@v5


### PR DESCRIPTION
Added lightweight energy and CO₂ estimation via Green Coding’s Eco-CI GitHub Action to the KADAI CI workflow.
Eco-CI provides transparent, reproducible energy metrics by estimating CPU and memory consumption of GitHub runners during build and test phases.

Each selected job now starts and ends an Eco-CI measurement cycle with labeled checkpoints for key phases (build, backend tests, e2e tests).
A single PR comment summarizes the results, and energy badges are shown in the respective job summaries.

Changes

* Added start-measurement, get-measurement, and display-results steps to:
compile_backend, test_backend_17 (H2 only, for reproducibility), test_e2e
* Set continue-on-error: true for all Eco-CI steps to prevent workflow failures.
* Granted pull-requests: write permission (for PR comment posting in test_e2e).

**To see the results of the Eco CI measurements, you need to go under "Actions" -> open the job -> "Summary".**