### PR TITLE
Closes #1532 - Fix querying Task-Summaries with additional user-information fails on Postgres and DB2

### DIFF
--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -2200,6 +2200,11 @@ public class TaskQueryImpl implements TaskQuery {
       throw new IllegalArgumentException(
           "The params \"lockResultsEquals\" and \"selectAndClaim\"" + " cannot be used together!");
     }
+    if (joinWithUserInfo && lockResults != null && lockResults != 0) {
+      throw new IllegalArgumentException(
+          "The params \"lockResultsEquals\" and \"joinWithUserInfo\""
+              + " cannot be used together!");
+    }
     if (withoutAttachment
         && (attachmentChannelIn != null
             || attachmentChannelLike != null

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -55,7 +55,7 @@ public class TaskQuerySqlProvider {
         + "<if test=\"addAttachmentClassificationNameToSelectClauseForOrdering\">, "
         + "ac.NAME as ACNAME </if>"
         + "<if test=\"addWorkbasketNameToSelectClauseForOrdering\">, w.NAME as WNAME </if>"
-        + "<if test=\"joinWithUserInfo\">, u.LONG_NAME</if>"
+        + "<if test=\"joinWithUserInfo and lockResults == 0\">, u.LONG_NAME</if>"
         + groupByPorIfActive()
         + groupBySorIfActive()
         + "FROM TASK t "
@@ -74,7 +74,7 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfo and lockResults == 0\">"
         + "LEFT JOIN USER_INFO u ON t.owner = u.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -327,7 +327,6 @@ public class TaskQuerySqlProvider {
         .filter(column -> column.startsWith("t"))
         .collect(Collectors.joining(", "));
   }
-
 
   private static String db2selectFields() {
     // needs to be the same order as the commonSelectFields (TaskQueryColumnValue)

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -55,7 +55,7 @@ public class TaskQuerySqlProvider {
         + "<if test=\"addAttachmentClassificationNameToSelectClauseForOrdering\">, "
         + "ac.NAME as ACNAME </if>"
         + "<if test=\"addWorkbasketNameToSelectClauseForOrdering\">, w.NAME as WNAME </if>"
-        + "<if test=\"joinWithUserInfo and lockResults == 0\">, u.LONG_NAME</if>"
+        + "<if test=\"joinWithUserInfo\">, u.LONG_NAME</if>"
         + groupByPorIfActive()
         + groupBySorIfActive()
         + "FROM TASK t "
@@ -74,7 +74,7 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo and lockResults == 0\">"
+        + "<if test=\"joinWithUserInfo\">"
         + "LEFT JOIN USER_INFO u ON t.owner = u.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksAccTest.java
@@ -21,6 +21,7 @@ package acceptance.task.query;
 import static io.kadai.common.api.BaseQuery.SortDirection.ASCENDING;
 import static io.kadai.common.api.BaseQuery.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -96,21 +97,26 @@ class QueryTasksAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "user-1-1")
   @Test
-  void should_NotSetOwnerLongNameOfTask_When_PropertyAndLockingEnabled() throws Exception {
+  void should_ThrowIllegalArgumentException_When_UserInfoPropertyAndLockingEnabled()
+      throws Exception {
     KadaiConfiguration kadaiConfiguration =
         new Builder(AbstractAccTest.kadaiConfiguration).addAdditionalUserInfo(true).build();
     KadaiEngine kadaiEngine = KadaiEngine.buildKadaiEngine(kadaiConfiguration);
 
-    List<TaskSummary> tasks =
-        kadaiEngine
-            .getTaskService()
-            .createTaskQuery()
-            .lockResultsEquals(64)
-            .idIn("TKI:000000000000000000000000000000000000")
-            .list();
+    final ThrowingCallable call =
+        () ->
+            kadaiEngine
+                .getTaskService()
+                .createTaskQuery()
+                .lockResultsEquals(64)
+                .idIn("TKI:000000000000000000000000000000000000")
+                .list();
 
-    assertThat(tasks).hasSize(1);
-    assertThat(tasks.get(0)).extracting(TaskSummary::getOwnerLongName).isNull();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(call)
+        .extracting(IllegalArgumentException::getMessage)
+        .isEqualTo(
+            "The params \"lockResultsEquals\" and \"joinWithUserInfo\" cannot be used together!");
   }
 
   @WithAccessId(user = "user-1-1")

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksAccTest.java
@@ -96,6 +96,25 @@ class QueryTasksAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "user-1-1")
   @Test
+  void should_NotSetOwnerLongNameOfTask_When_PropertyAndLockingEnabled() throws Exception {
+    KadaiConfiguration kadaiConfiguration =
+        new Builder(AbstractAccTest.kadaiConfiguration).addAdditionalUserInfo(true).build();
+    KadaiEngine kadaiEngine = KadaiEngine.buildKadaiEngine(kadaiConfiguration);
+
+    List<TaskSummary> tasks =
+        kadaiEngine
+            .getTaskService()
+            .createTaskQuery()
+            .lockResultsEquals(64)
+            .idIn("TKI:000000000000000000000000000000000000")
+            .list();
+
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.get(0)).extracting(TaskSummary::getOwnerLongName).isNull();
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
   void should_NotSetOwnerLongNameOfTask_When_PropertyDisabled() throws Exception {
     KadaiConfiguration kadaiConfiguration =
         new Builder(AbstractAccTest.kadaiConfiguration).addAdditionalUserInfo(false).build();


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
  - Fixed a bug where the combination of `lockResults` and `joinWithUserInfo` in `TaskQueryImpl` would alllow construction of an invalid query - leading to a runtime exception being thrown by MyBatis due to the DBMS complaining. We now forbid the combination by throwing an `IllegalArgumentException` when constructing `TaskQueryImpl`.