### PR TITLE
Closes #1705 - do not run on non-PR pushes & do not create duplicated runs on pushes to PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,8 +9,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event_name }}/${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   JAVA_VERSION: 17

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,8 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches-ignore:
-      - dependabot/**
+    branches:
+      - master
     tags:
       - v[0-9]+\.[0-9]+\.[0-9]+
   pull_request:


### PR DESCRIPTION
Resolves #1705

The changes to the `concurrency` section are a simplification and the implementation of a best practice (do not auto-cancel runs on master, e.g. during a deployment). If I should create a separate PR for this, let me know.

## Definition of Done

- [ ] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [ ] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
