### PR TITLE
Closes #1714 - Skip SonarQube-Upload on forks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -830,14 +830,16 @@ jobs:
   upload_to_sonar:
     runs-on: ubuntu-22.04
     name: Upload SonarQube analysis to sonarcloud
-    # neither on release nor forks nor dependabot
     needs: [ test_frontend, test_e2e, test_backend_17, test_backend_21 ]
+    # Runs on every push to main and on PRs originating from kadai-io/kadai (not forks).
+    # Skipped for release tags, dependabot PRs, and if any test job failed.
     if: |
       always() &&
       github.repository == 'kadai-io/kadai' &&
+      ( github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository ) &&
       !startsWith(github.ref, 'refs/tags') &&
       !startsWith(github.head_ref || github.ref_name, 'dependabot/') &&
-      github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' &&
       needs.detect_changes.outputs.code_changed == 'true' &&
       needs.test_frontend.result != 'failure' &&
       needs.test_e2e.result != 'failure' &&


### PR DESCRIPTION
The job "Upload SonarQube analysis to sonarcloud" fails if it runs from a forked repository. Reason is of course, that the secrets are missing.
Example run: https://github.com/davidkopp/kadai/actions/runs/22254262523/job/64382969578

The current job definition has a mistake in the condition. This PR fixes this.

## Definition of Done

- [ ] The corresponding ticket is in state `In Review`
- [ ] The corresponding ticket is attached to this Pull-Request
- [ ] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate