### PR TITLE
Closes #1793 - Add `BeforeTransferTaskProvider` SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Currently, KADAI provides the following SPIs:
 * [`io.kadai.spi.task.api.AfterRequestReviewProvider`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/AfterRequestReviewProvider.java)
 * [`io.kadai.spi.task.api.BeforeRequestChangesProvider`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/BeforeRequestChangesProvider.java)
 * [`io.kadai.spi.task.api.BeforeRequestReviewProvider`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/BeforeRequestReviewProvider.java)
+* [`io.kadai.spi.task.api.BeforeTransferTaskProvider`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/BeforeTransferTaskProvider.java)
 * [`io.kadai.spi.task.api.CreateTaskPreprocessor`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/CreateTaskPreprocessor.java)
 * [`io.kadai.spi.task.api.ReviewRequiredProvider`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/task/api/ReviewRequiredProvider.java)
 * [`io.kadai.spi.user.api.RefreshUserPostprocessor`](https://github.com/kadai-io/kadai/blob/master/lib/kadai-core/src/main/java/io/kadai/spi/user/api/RefreshUserPostprocessor.java)

--- a/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
@@ -237,7 +237,7 @@ public class TransferWithBeforeTransferSpiAccTest {
 
       TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
       assertThat(ex).isNotNull();
-      assertThat(ex.getReason()).isEqualTo("Transfer always denied by SPI");
+      assertThat(ex.getReason()).isEqualTo("Transfer always denied by Test-SPI");
       assertThat(ex.getSourceWorkbasketId()).isEqualTo(defaultWorkbasketSummary.getId());
       assertThat(ex.getDestinationWorkbasketId()).isEqualTo(destinationWorkbasketSummary.getId());
     }
@@ -254,7 +254,7 @@ public class TransferWithBeforeTransferSpiAccTest {
 
       TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
       assertThat(ex).isNotNull();
-      assertThat(ex.getReason()).isEqualTo("Transfer always denied by SPI");
+      assertThat(ex.getReason()).isEqualTo("Transfer always denied by Test-SPI");
     }
 
     @WithAccessId(user = "user-1-1")
@@ -329,7 +329,7 @@ public class TransferWithBeforeTransferSpiAccTest {
       TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
       assertThat(ex.getErrorCode().getKey()).isEqualTo("TASK_TRANSFER_CHECK_FAILED");
       assertThat(ex.getErrorCode().getMessageVariables())
-          .containsEntry("reason", "Transfer always denied by SPI")
+          .containsEntry("reason", "Transfer always denied by Test-SPI")
           .containsEntry("sourceWorkbasketId", defaultWorkbasketSummary.getId())
           .containsEntry("destinationWorkbasketId", destinationWorkbasketSummary.getId());
     }

--- a/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
@@ -257,6 +257,7 @@ public class TransferWithBeforeTransferSpiAccTest {
       assertThat(ex.getReason()).isEqualTo("Transfer always denied by Test-SPI");
     }
 
+    @SuppressWarnings("checkstyle:CatchParameterName")
     @WithAccessId(user = "user-1-1")
     @Test
     void should_NotTransferTask_When_SpiDeniesTransfer() throws Exception {
@@ -264,7 +265,7 @@ public class TransferWithBeforeTransferSpiAccTest {
 
       try {
         taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
-      } catch (TransferCheckException e) {
+      } catch (TransferCheckException _) {
         // expected
       }
 

--- a/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/transfer/TransferWithBeforeTransferSpiAccTest.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package acceptance.task.transfer;
+
+import static io.kadai.testapi.DefaultTestEntities.defaultTestClassification;
+import static io.kadai.testapi.DefaultTestEntities.defaultTestWorkbasket;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+
+import io.kadai.classification.api.ClassificationService;
+import io.kadai.classification.api.models.ClassificationSummary;
+import io.kadai.common.api.BulkOperationResults;
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.common.api.exceptions.KadaiException;
+import io.kadai.spi.task.api.BeforeTransferTaskProvider;
+import io.kadai.task.api.TaskService;
+import io.kadai.task.api.TaskState;
+import io.kadai.task.api.exceptions.TransferCheckException;
+import io.kadai.task.api.models.ObjectReference;
+import io.kadai.task.api.models.Task;
+import io.kadai.testapi.DefaultTestEntities;
+import io.kadai.testapi.KadaiInject;
+import io.kadai.testapi.KadaiIntegrationTest;
+import io.kadai.testapi.WithServiceProvider;
+import io.kadai.testapi.builder.TaskBuilder;
+import io.kadai.testapi.builder.WorkbasketAccessItemBuilder;
+import io.kadai.testapi.security.WithAccessId;
+import io.kadai.workbasket.api.WorkbasketPermission;
+import io.kadai.workbasket.api.WorkbasketService;
+import io.kadai.workbasket.api.models.Workbasket;
+import io.kadai.workbasket.api.models.WorkbasketSummary;
+import java.time.Instant;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@KadaiIntegrationTest
+public class TransferWithBeforeTransferSpiAccTest {
+
+  ClassificationSummary defaultClassificationSummary;
+  WorkbasketSummary defaultWorkbasketSummary;
+  WorkbasketSummary destinationWorkbasketSummary;
+  ObjectReference defaultObjectReference;
+
+  @WithAccessId(user = "businessadmin")
+  @BeforeAll
+  void setup(ClassificationService classificationService, WorkbasketService workbasketService)
+      throws Exception {
+    defaultClassificationSummary =
+        defaultTestClassification().buildAndStoreAsSummary(classificationService);
+    defaultWorkbasketSummary = defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService);
+    destinationWorkbasketSummary =
+        defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService);
+
+    WorkbasketAccessItemBuilder.newWorkbasketAccessItem()
+        .workbasketId(defaultWorkbasketSummary.getId())
+        .accessId("user-1-1")
+        .permission(WorkbasketPermission.READ)
+        .permission(WorkbasketPermission.READTASKS)
+        .permission(WorkbasketPermission.EDITTASKS)
+        .permission(WorkbasketPermission.APPEND)
+        .permission(WorkbasketPermission.TRANSFER)
+        .buildAndStore(workbasketService);
+
+    WorkbasketAccessItemBuilder.newWorkbasketAccessItem()
+        .workbasketId(destinationWorkbasketSummary.getId())
+        .accessId("user-1-1")
+        .permission(WorkbasketPermission.READ)
+        .permission(WorkbasketPermission.READTASKS)
+        .permission(WorkbasketPermission.EDITTASKS)
+        .permission(WorkbasketPermission.APPEND)
+        .permission(WorkbasketPermission.TRANSFER)
+        .buildAndStore(workbasketService);
+
+    defaultObjectReference = DefaultTestEntities.defaultTestObjectReference().build();
+  }
+
+  private TaskBuilder createTaskInState(TaskState state) {
+    TaskBuilder builder =
+        TaskBuilder.newTask()
+            .classificationSummary(defaultClassificationSummary)
+            .workbasketSummary(defaultWorkbasketSummary)
+            .primaryObjRef(defaultObjectReference);
+    if (state == TaskState.CLAIMED) {
+      builder.owner("user-1-1").state(TaskState.CLAIMED).claimed(Instant.now());
+    } else {
+      builder.state(state);
+    }
+    return builder;
+  }
+
+  private TaskBuilder createReadyTask() {
+    return createTaskInState(TaskState.READY);
+  }
+
+  static class AlwaysDenyTransfer implements BeforeTransferTaskProvider {
+    @Override
+    public void initialize(KadaiEngine kadaiEngine) {
+      // no-op
+    }
+
+    @Override
+    public void checkTransferAllowed(Task task, Workbasket destinationWorkbasket)
+        throws TransferCheckException {
+      throw new TransferCheckException(
+          "Transfer always denied by Test-SPI",
+          task.getWorkbasketSummary().getId(),
+          destinationWorkbasket.getId());
+    }
+  }
+
+  static class AlwaysAllowTransfer implements BeforeTransferTaskProvider {
+    @Override
+    public void initialize(KadaiEngine kadaiEngine) {
+      // no-op
+    }
+
+    @Override
+    public void checkTransferAllowed(Task task, Workbasket destinationWorkbasket) {
+      // allowed
+    }
+  }
+
+  static class DenySpecificWorkbasket implements BeforeTransferTaskProvider {
+    static String deniedWorkbasketId;
+
+    @Override
+    public void initialize(KadaiEngine kadaiEngine) {
+      // no-op
+    }
+
+    @Override
+    public void checkTransferAllowed(Task task, Workbasket destinationWorkbasket)
+        throws TransferCheckException {
+      if (destinationWorkbasket.getId().equals(deniedWorkbasketId)) {
+        throw new TransferCheckException(
+            "Transfer to this workbasket is not allowed",
+            task.getWorkbasketSummary().getId(),
+            destinationWorkbasket.getId());
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeTransferTaskProvider.class,
+      serviceProviders = AlwaysAllowTransfer.class)
+  class SpiAllowsTransfer {
+
+    @KadaiInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_TransferTask_When_SpiAllowsTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      Task transferred = taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      assertThat(transferred.getWorkbasketSummary().getId())
+          .isEqualTo(destinationWorkbasketSummary.getId());
+      assertThat(transferred.isTransferred()).isTrue();
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_TransferTaskWithOwner_When_SpiAllowsTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      Task transferred =
+          taskService.transferWithOwner(
+              task.getId(), destinationWorkbasketSummary.getId(), "user-1-1");
+
+      assertThat(transferred.getWorkbasketSummary().getId())
+          .isEqualTo(destinationWorkbasketSummary.getId());
+      assertThat(transferred.getOwner()).isEqualTo("user-1-1");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_TransferBulkTasks_When_SpiAllowsTransfer() throws Exception {
+      Task task1 = createReadyTask().buildAndStore(taskService);
+      Task task2 = createReadyTask().buildAndStore(taskService);
+
+      BulkOperationResults<String, KadaiException> result =
+          taskService.transferTasks(
+              destinationWorkbasketSummary.getId(), List.of(task1.getId(), task2.getId()));
+
+      assertThat(result.containsErrors()).isFalse();
+
+      Task transferred1 = taskService.getTask(task1.getId());
+      Task transferred2 = taskService.getTask(task2.getId());
+      assertThat(transferred1.getWorkbasketSummary().getId())
+          .isEqualTo(destinationWorkbasketSummary.getId());
+      assertThat(transferred2.getWorkbasketSummary().getId())
+          .isEqualTo(destinationWorkbasketSummary.getId());
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeTransferTaskProvider.class,
+      serviceProviders = AlwaysDenyTransfer.class)
+  class SpiDeniesTransfer {
+
+    @KadaiInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ThrowTransferCheckException_When_SpiDeniesTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () -> taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
+      assertThat(ex).isNotNull();
+      assertThat(ex.getReason()).isEqualTo("Transfer always denied by SPI");
+      assertThat(ex.getSourceWorkbasketId()).isEqualTo(defaultWorkbasketSummary.getId());
+      assertThat(ex.getDestinationWorkbasketId()).isEqualTo(destinationWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ThrowTransferCheckException_When_SpiDeniesTransferWithOwner() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () ->
+              taskService.transferWithOwner(
+                  task.getId(), destinationWorkbasketSummary.getId(), "user-1-1");
+
+      TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
+      assertThat(ex).isNotNull();
+      assertThat(ex.getReason()).isEqualTo("Transfer always denied by SPI");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_NotTransferTask_When_SpiDeniesTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      try {
+        taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+      } catch (TransferCheckException e) {
+        // expected
+      }
+
+      Task persistentTask = taskService.getTask(task.getId());
+      assertThat(persistentTask.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_NotTransferAnyBulkTasks_When_SpiDeniesTransfer() throws Exception {
+      Task task1 = createReadyTask().buildAndStore(taskService);
+      Task task2 = createReadyTask().buildAndStore(taskService);
+
+      BulkOperationResults<String, KadaiException> result =
+          taskService.transferTasks(
+              destinationWorkbasketSummary.getId(), List.of(task1.getId(), task2.getId()));
+
+      assertThat(result.containsErrors()).isTrue();
+      assertThat(result.getFailedIds()).containsExactlyInAnyOrder(task1.getId(), task2.getId());
+
+      // Verify no tasks were transferred
+      Task persistentTask1 = taskService.getTask(task1.getId());
+      Task persistentTask2 = taskService.getTask(task2.getId());
+      assertThat(persistentTask1.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+      assertThat(persistentTask2.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_NotTransferAnyBulkTasksWithOwner_When_SpiDeniesTransfer() throws Exception {
+      Task task1 = createReadyTask().buildAndStore(taskService);
+      Task task2 = createReadyTask().buildAndStore(taskService);
+
+      BulkOperationResults<String, KadaiException> result =
+          taskService.transferTasksWithOwner(
+              destinationWorkbasketSummary.getId(),
+              List.of(task1.getId(), task2.getId()),
+              "user-1-1");
+
+      assertThat(result.containsErrors()).isTrue();
+
+      // Verify no tasks were transferred
+      Task persistentTask1 = taskService.getTask(task1.getId());
+      Task persistentTask2 = taskService.getTask(task2.getId());
+      assertThat(persistentTask1.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+      assertThat(persistentTask2.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ContainProperErrorCodeInException_When_SpiDeniesTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () -> taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      TransferCheckException ex = catchThrowableOfType(TransferCheckException.class, call);
+      assertThat(ex.getErrorCode().getKey()).isEqualTo("TASK_TRANSFER_CHECK_FAILED");
+      assertThat(ex.getErrorCode().getMessageVariables())
+          .containsEntry("reason", "Transfer always denied by SPI")
+          .containsEntry("sourceWorkbasketId", defaultWorkbasketSummary.getId())
+          .containsEntry("destinationWorkbasketId", destinationWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_TransferByKeyDomainDenied_When_SpiDeniesTransfer() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () ->
+              taskService.transfer(
+                  task.getId(),
+                  destinationWorkbasketSummary.getKey(),
+                  destinationWorkbasketSummary.getDomain());
+
+      assertThatThrownBy(call).isInstanceOf(TransferCheckException.class);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeTransferTaskProvider.class,
+      serviceProviders = DenySpecificWorkbasket.class)
+  class SpiDeniesSpecificWorkbasket {
+
+    @KadaiInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_AllowTransfer_When_SpiDoesNotDenyDestination() throws Exception {
+      DenySpecificWorkbasket.deniedWorkbasketId = "non-existing-id";
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      Task transferred = taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      assertThat(transferred.getWorkbasketSummary().getId())
+          .isEqualTo(destinationWorkbasketSummary.getId());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_DenyTransfer_When_SpiDeniesSpecificDestination() throws Exception {
+      DenySpecificWorkbasket.deniedWorkbasketId = destinationWorkbasketSummary.getId();
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () -> taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      assertThatThrownBy(call)
+          .isInstanceOf(TransferCheckException.class)
+          .hasMessageContaining("Transfer to this workbasket is not allowed");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ReturnEarlyAndNotTransferAny_When_SingleTaskFailsBulkCheck() throws Exception {
+      DenySpecificWorkbasket.deniedWorkbasketId = destinationWorkbasketSummary.getId();
+      Task task1 = createReadyTask().buildAndStore(taskService);
+      Task task2 = createReadyTask().buildAndStore(taskService);
+
+      BulkOperationResults<String, KadaiException> result =
+          taskService.transferTasks(
+              destinationWorkbasketSummary.getId(), List.of(task1.getId(), task2.getId()));
+
+      assertThat(result.containsErrors()).isTrue();
+      // Both tasks should fail because all are denied for this workbasket
+      assertThat(result.getFailedIds()).containsExactlyInAnyOrder(task1.getId(), task2.getId());
+
+      // Verify no tasks were transferred
+      Task persistentTask1 = taskService.getTask(task1.getId());
+      Task persistentTask2 = taskService.getTask(task2.getId());
+      assertThat(persistentTask1.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+      assertThat(persistentTask2.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeTransferTaskProvider.class,
+      serviceProviders = {AlwaysAllowTransfer.class, AlwaysDenyTransfer.class})
+  class MultipleSpisAreDefined {
+
+    @KadaiInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_DenyTransfer_When_AnySpiDenies() throws Exception {
+      Task task = createReadyTask().buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () -> taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      assertThatThrownBy(call).isInstanceOf(TransferCheckException.class);
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_DenyBulkTransfer_When_AnySpiDenies() throws Exception {
+      Task task1 = createReadyTask().buildAndStore(taskService);
+      Task task2 = createReadyTask().buildAndStore(taskService);
+
+      BulkOperationResults<String, KadaiException> result =
+          taskService.transferTasks(
+              destinationWorkbasketSummary.getId(), List.of(task1.getId(), task2.getId()));
+
+      assertThat(result.containsErrors()).isTrue();
+
+      // Verify no tasks were transferred
+      Task persistentTask1 = taskService.getTask(task1.getId());
+      Task persistentTask2 = taskService.getTask(task2.getId());
+      assertThat(persistentTask1.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+      assertThat(persistentTask2.getWorkbasketSummary().getId())
+          .isEqualTo(defaultWorkbasketSummary.getId());
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeTransferTaskProvider.class,
+      serviceProviders = AlwaysDenyTransfer.class)
+  class SpiDeniesClaimedTaskTransfer {
+
+    @KadaiInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_DenyTransfer_When_SpiDeniesClaimedTask() throws Exception {
+      Task task = createTaskInState(TaskState.CLAIMED).buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () -> taskService.transfer(task.getId(), destinationWorkbasketSummary.getId());
+
+      assertThatThrownBy(call).isInstanceOf(TransferCheckException.class);
+    }
+  }
+}

--- a/lib/kadai-core/src/main/java/io/kadai/common/internal/InternalKadaiEngine.java
+++ b/lib/kadai-core/src/main/java/io/kadai/common/internal/InternalKadaiEngine.java
@@ -26,6 +26,7 @@ import io.kadai.spi.task.internal.AfterRequestChangesManager;
 import io.kadai.spi.task.internal.AfterRequestReviewManager;
 import io.kadai.spi.task.internal.BeforeRequestChangesManager;
 import io.kadai.spi.task.internal.BeforeRequestReviewManager;
+import io.kadai.spi.task.internal.BeforeTransferTaskManager;
 import io.kadai.spi.task.internal.CreateTaskPreprocessorManager;
 import io.kadai.spi.task.internal.ReviewRequiredManager;
 import io.kadai.spi.task.internal.TaskDistributionManager;
@@ -178,4 +179,11 @@ public interface InternalKadaiEngine {
    * @return the {@linkplain io.kadai.spi.task.internal.TaskEndstatePreprocessorManager} instance
    */
   TaskEndstatePreprocessorManager getTaskEndstatePreprocessorManager();
+
+  /**
+   * Retrieves the {@linkplain BeforeTransferTaskManager}.
+   *
+   * @return the {@linkplain BeforeTransferTaskManager} instance
+   */
+  BeforeTransferTaskManager getBeforeTransferTaskManager();
 }

--- a/lib/kadai-core/src/main/java/io/kadai/common/internal/KadaiEngineImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/common/internal/KadaiEngineImpl.java
@@ -58,6 +58,7 @@ import io.kadai.spi.task.internal.AfterRequestChangesManager;
 import io.kadai.spi.task.internal.AfterRequestReviewManager;
 import io.kadai.spi.task.internal.BeforeRequestChangesManager;
 import io.kadai.spi.task.internal.BeforeRequestReviewManager;
+import io.kadai.spi.task.internal.BeforeTransferTaskManager;
 import io.kadai.spi.task.internal.CreateTaskPreprocessorManager;
 import io.kadai.spi.task.internal.ReviewRequiredManager;
 import io.kadai.spi.task.internal.TaskDistributionManager;
@@ -121,6 +122,7 @@ public class KadaiEngineImpl implements KadaiEngine {
   private final BeforeRequestChangesManager beforeRequestChangesManager;
   private final AfterRequestChangesManager afterRequestChangesManager;
   private final TaskEndstatePreprocessorManager taskEndstatePreprocessorManager;
+  private final BeforeTransferTaskManager beforeTransferTaskManager;
 
   private final InternalKadaiEngineImpl internalKadaiEngineImpl;
   private final WorkingTimeCalculator workingTimeCalculator;
@@ -208,6 +210,7 @@ public class KadaiEngineImpl implements KadaiEngine {
     beforeRequestChangesManager = new BeforeRequestChangesManager(this);
     afterRequestChangesManager = new AfterRequestChangesManager(this);
     taskEndstatePreprocessorManager = new TaskEndstatePreprocessorManager();
+    beforeTransferTaskManager = new BeforeTransferTaskManager(this);
 
     // don't remove, to reset possible explicit mode
     this.mode = connectionManagementMode;
@@ -661,6 +664,11 @@ public class KadaiEngineImpl implements KadaiEngine {
     @Override
     public TaskEndstatePreprocessorManager getTaskEndstatePreprocessorManager() {
       return taskEndstatePreprocessorManager;
+    }
+
+    @Override
+    public BeforeTransferTaskManager getBeforeTransferTaskManager() {
+      return beforeTransferTaskManager;
     }
   }
 }

--- a/lib/kadai-core/src/main/java/io/kadai/spi/task/api/BeforeTransferTaskProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/spi/task/api/BeforeTransferTaskProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.spi.task.api;
+
+import io.kadai.common.api.KadaiInitializable;
+import io.kadai.task.api.exceptions.TransferCheckException;
+import io.kadai.task.api.models.Task;
+import io.kadai.workbasket.api.models.Workbasket;
+
+/**
+ * The BeforeTransferTaskProvider allows to implement customized validation
+ * logic before a {@linkplain Task} is transferred to a destination
+ * {@linkplain Workbasket}.
+ *
+ * <p>Implementations can deny the transfer by throwing a
+ * {@linkplain TransferCheckException}.
+ */
+public interface BeforeTransferTaskProvider extends KadaiInitializable {
+
+  /**
+   * Validate whether the transfer of a {@linkplain Task} to the given destination {@linkplain
+   * Workbasket} is allowed.
+   *
+   * <p>This SPI is executed within the same transaction staple as the transfer operation (e.g.
+   * {@linkplain io.kadai.task.api.TaskService#transfer(String, String)} or {@linkplain
+   * io.kadai.task.api.TaskService#transferTasks(String, java.util.List)}).
+   *
+   * <p>This SPI is executed with the same {@linkplain io.kadai.common.api.security.UserPrincipal}
+   * and {@linkplain io.kadai.common.api.security.GroupPrincipal} as in the transfer operation.
+   *
+   * @param task the {@linkplain Task} that is about to be transferred
+   * @param destinationWorkbasket the destination {@linkplain Workbasket} the {@linkplain Task} will
+   *     be transferred to
+   * @throws TransferCheckException if the transfer is not allowed
+   */
+  void checkTransferAllowed(Task task, Workbasket destinationWorkbasket)
+      throws TransferCheckException;
+}
+
+

--- a/lib/kadai-core/src/main/java/io/kadai/spi/task/internal/BeforeTransferTaskManager.java
+++ b/lib/kadai-core/src/main/java/io/kadai/spi/task/internal/BeforeTransferTaskManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.spi.task.internal;
+
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.common.api.exceptions.SystemException;
+import io.kadai.common.internal.util.SpiLoader;
+import io.kadai.spi.task.api.BeforeTransferTaskProvider;
+import io.kadai.task.api.exceptions.TransferCheckException;
+import io.kadai.task.api.models.Task;
+import io.kadai.workbasket.api.models.Workbasket;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BeforeTransferTaskManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BeforeTransferTaskManager.class);
+
+  private final List<BeforeTransferTaskProvider> beforeTransferTaskProviders;
+
+  public BeforeTransferTaskManager(KadaiEngine kadaiEngine) {
+    beforeTransferTaskProviders = SpiLoader.load(BeforeTransferTaskProvider.class);
+    for (BeforeTransferTaskProvider serviceProvider : beforeTransferTaskProviders) {
+      serviceProvider.initialize(kadaiEngine);
+      LOGGER.info(
+          "Registered BeforeTransferTaskProvider service provider: {}",
+          serviceProvider.getClass().getName());
+    }
+    if (beforeTransferTaskProviders.isEmpty()) {
+      LOGGER.info(
+          "No BeforeTransferTaskProvider service provider found. "
+              + "Running without any BeforeTransferTaskProvider implementation.");
+    }
+  }
+
+  public boolean isEnabled() {
+    return !beforeTransferTaskProviders.isEmpty();
+  }
+
+  public void checkTransferAllowed(Task task, Workbasket destinationWorkbasket)
+      throws TransferCheckException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
+          "Sending Task to BeforeTransferTaskProvider service providers: {}", task);
+    }
+    for (BeforeTransferTaskProvider serviceProvider : beforeTransferTaskProviders) {
+      try {
+        serviceProvider.checkTransferAllowed(task, destinationWorkbasket);
+      } catch (TransferCheckException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new SystemException(
+            String.format(
+                "service provider '%s' threw an exception", serviceProvider.getClass().getName()),
+            e);
+      }
+    }
+  }
+}
+

--- a/lib/kadai-core/src/main/java/io/kadai/task/api/TaskService.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/api/TaskService.java
@@ -38,6 +38,7 @@ import io.kadai.task.api.exceptions.ServiceLevelViolationException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskCommentNotFoundException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.task.api.models.Attachment;
 import io.kadai.task.api.models.ObjectReference;
 import io.kadai.task.api.models.Task;
@@ -579,7 +580,8 @@ public interface TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return transfer(taskId, destinationWorkbasketId, true);
   }
 
@@ -603,12 +605,15 @@ public interface TaskService {
    *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
    * @throws InvalidTaskStateException if the {@linkplain Task} is in one of the {@linkplain
    *     TaskState#END_STATES}
+   * @throws TransferCheckException if a {@linkplain
+   *     io.kadai.spi.task.api.BeforeTransferTaskProvider} denies the transfer
    */
   Task transfer(String taskId, String destinationWorkbasketId, boolean setTransferFlag)
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException;
+          InvalidTaskStateException,
+          TransferCheckException;
 
   /**
    * Transfers a {@linkplain Task} to another {@linkplain Workbasket} while always setting
@@ -628,7 +633,8 @@ public interface TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return transfer(taskId, workbasketKey, domain, true);
   }
 
@@ -654,12 +660,15 @@ public interface TaskService {
    *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
    * @throws InvalidTaskStateException if the {@linkplain Task} is in one of the {@linkplain
    *     TaskState#END_STATES}
+   * @throws TransferCheckException if a {@link io.kadai.spi.task.api.BeforeTransferTaskProvider
+   *     BeforeTransferTaskProvider} denies the transfer
    */
   Task transfer(String taskId, String workbasketKey, String domain, boolean setTransferFlag)
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException;
+          InvalidTaskStateException,
+          TransferCheckException;
 
   /**
    * Transfers a {@linkplain Task} to another {@linkplain Workbasket} and sets the owner of the
@@ -679,7 +688,8 @@ public interface TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return transferWithOwner(taskId, destinationWorkbasketId, owner, true);
   }
 
@@ -705,13 +715,16 @@ public interface TaskService {
    *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
    * @throws InvalidTaskStateException if the {@linkplain Task} is in one of the {@linkplain
    *     TaskState#END_STATES}
+   * @throws TransferCheckException if a {@link io.kadai.spi.task.api.BeforeTransferTaskProvider
+   *     BeforeTransferTaskProvider} denies the transfer
    */
   Task transferWithOwner(
       String taskId, String destinationWorkbasketId, String owner, boolean setTransferFlag)
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException;
+          InvalidTaskStateException,
+          TransferCheckException;
 
   /**
    * Transfers a {@linkplain Task} to another {@linkplain Workbasket} and sets the owner of the
@@ -733,7 +746,8 @@ public interface TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return transferWithOwner(taskId, workbasketKey, domain, owner, true);
   }
 
@@ -761,13 +775,16 @@ public interface TaskService {
    *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
    * @throws InvalidTaskStateException if the {@linkplain Task} is in one of the {@linkplain
    *     TaskState#END_STATES}
+   * @throws TransferCheckException if a {@link io.kadai.spi.task.api.BeforeTransferTaskProvider
+   *     BeforeTransferTaskProvider} denies the transfer
    */
   Task transferWithOwner(
       String taskId, String workbasketKey, String domain, String owner, boolean setTransferFlag)
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException;
+          InvalidTaskStateException,
+          TransferCheckException;
 
   /**
    * Transfers a List of {@linkplain Task Tasks} to another {@linkplain Workbasket} while always

--- a/lib/kadai-core/src/main/java/io/kadai/task/api/exceptions/TransferCheckException.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/api/exceptions/TransferCheckException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.task.api.exceptions;
+
+import io.kadai.common.api.exceptions.ErrorCode;
+import io.kadai.common.api.exceptions.KadaiException;
+import io.kadai.task.api.models.Task;
+import io.kadai.workbasket.api.models.Workbasket;
+import java.util.Map;
+
+/**
+ * This exception is thrown when a BeforeTransferTaskProvider denies the transfer of a
+ * {@linkplain Task} to a destination {@linkplain Workbasket}.
+ */
+public class TransferCheckException extends KadaiException {
+
+  public static final String ERROR_KEY = "TASK_TRANSFER_CHECK_FAILED";
+
+  private final String reason;
+  private final String sourceWorkbasketId;
+  private final String destinationWorkbasketId;
+
+  public TransferCheckException(
+      String reason, String sourceWorkbasketId, String destinationWorkbasketId) {
+    super(
+        String.format(
+            "Transfer of Task from Workbasket '%s' to Workbasket '%s' was denied: %s",
+            sourceWorkbasketId, destinationWorkbasketId, reason),
+        ErrorCode.of(
+            ERROR_KEY,
+            Map.ofEntries(
+                Map.entry("reason", ensureNullIsHandled(reason)),
+                Map.entry("sourceWorkbasketId", ensureNullIsHandled(sourceWorkbasketId)),
+                Map.entry(
+                    "destinationWorkbasketId", ensureNullIsHandled(destinationWorkbasketId)))));
+    this.reason = reason;
+    this.sourceWorkbasketId = sourceWorkbasketId;
+    this.destinationWorkbasketId = destinationWorkbasketId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public String getSourceWorkbasketId() {
+    return sourceWorkbasketId;
+  }
+
+  public String getDestinationWorkbasketId() {
+    return destinationWorkbasketId;
+  }
+}
+
+

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskServiceImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskServiceImpl.java
@@ -92,6 +92,7 @@ import io.kadai.task.api.exceptions.ServiceLevelViolationException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskCommentNotFoundException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.task.api.models.Attachment;
 import io.kadai.task.api.models.AttachmentSummary;
 import io.kadai.task.api.models.ObjectReference;
@@ -489,7 +490,8 @@ public class TaskServiceImpl implements TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return taskTransferrer.transfer(taskId, destinationWorkbasketId, setTransferFlag);
   }
 
@@ -498,7 +500,8 @@ public class TaskServiceImpl implements TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return taskTransferrer.transfer(taskId, workbasketKey, domain, setTransferFlag);
   }
 
@@ -508,7 +511,8 @@ public class TaskServiceImpl implements TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return taskTransferrer.transferWithOwner(
         taskId, destinationWorkbasketId, owner, setTransferFlag);
   }
@@ -519,7 +523,8 @@ public class TaskServiceImpl implements TaskService {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     return taskTransferrer.transferWithOwner(taskId, workbasketKey, domain, owner, setTransferFlag);
   }
 

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskTransferrer.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskTransferrer.java
@@ -299,8 +299,6 @@ final class TaskTransferrer {
         beforeTransferTaskManager.checkTransferAllowed(task, destinationWorkbasketFull);
       } catch (KadaiException e) {
         spiErrors.addError(taskSummary.getId(), e);
-      } catch (Exception e) {
-        LOGGER.error("Error loading task '{}' for SPI check", taskSummary.getId(), e);
       }
     }
     return spiErrors;

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskTransferrer.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskTransferrer.java
@@ -31,9 +31,11 @@ import io.kadai.common.internal.util.ObjectAttributeChangeDetector;
 import io.kadai.spi.history.api.KadaiEventPublisher;
 import io.kadai.spi.history.api.events.task.TaskTransferredEvent;
 import io.kadai.spi.history.internal.SimpleKadaiEventPublisherImpl;
+import io.kadai.spi.task.internal.BeforeTransferTaskManager;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.api.exceptions.InvalidTaskStateException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import io.kadai.task.internal.models.TaskImpl;
@@ -42,6 +44,7 @@ import io.kadai.workbasket.api.WorkbasketPermission;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.exceptions.NotAuthorizedOnWorkbasketException;
 import io.kadai.workbasket.api.exceptions.WorkbasketNotFoundException;
+import io.kadai.workbasket.api.models.Workbasket;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
 import io.kadai.workbasket.internal.WorkbasketQueryImpl;
 import java.time.Instant;
@@ -54,15 +57,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This class is responsible for the transfer of Tasks to another Workbasket. */
 final class TaskTransferrer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaskTransferrer.class);
 
   private final InternalKadaiEngine kadaiEngine;
   private final WorkbasketService workbasketService;
   private final TaskServiceImpl taskService;
   private final TaskMapper taskMapper;
   private final KadaiEventPublisher<TaskTransferredEvent> eventPublisher;
+  private final BeforeTransferTaskManager beforeTransferTaskManager;
 
   TaskTransferrer(
       InternalKadaiEngine kadaiEngine, TaskMapper taskMapper, TaskServiceImpl taskService) {
@@ -71,13 +79,15 @@ final class TaskTransferrer {
     this.taskMapper = taskMapper;
     this.workbasketService = kadaiEngine.getEngine().getWorkbasketService();
     this.eventPublisher = new SimpleKadaiEventPublisherImpl<>(kadaiEngine.getKadaiEventBroker());
+    this.beforeTransferTaskManager = kadaiEngine.getBeforeTransferTaskManager();
   }
 
   Task transfer(String taskId, String destinationWorkbasketId, boolean setTransferFlag)
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     WorkbasketSummary destinationWorkbasket =
         workbasketService.getWorkbasket(destinationWorkbasketId).asSummary();
     return transferSingleTask(taskId, destinationWorkbasket, null, setTransferFlag);
@@ -91,7 +101,8 @@ final class TaskTransferrer {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     WorkbasketSummary destinationWorkbasket =
         workbasketService.getWorkbasket(destinationWorkbasketKey, destinationDomain).asSummary();
     return transferSingleTask(taskId, destinationWorkbasket, null, setTransferFlag);
@@ -157,7 +168,8 @@ final class TaskTransferrer {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     WorkbasketSummary destinationWorkbasket =
         workbasketService.getWorkbasket(destinationWorkbasketId).asSummary();
     return transferSingleTask(taskId, destinationWorkbasket, owner, setTransferFlag);
@@ -172,7 +184,8 @@ final class TaskTransferrer {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     WorkbasketSummary destinationWorkbasket =
         workbasketService.getWorkbasket(destinationWorkbasketKey, destinationDomain).asSummary();
     return transferSingleTask(taskId, destinationWorkbasket, owner, setTransferFlag);
@@ -183,7 +196,8 @@ final class TaskTransferrer {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     try {
       kadaiEngine.openConnection();
       TaskImpl task = (TaskImpl) taskService.getTask(taskId);
@@ -193,6 +207,12 @@ final class TaskTransferrer {
 
       WorkbasketSummary originWorkbasket = task.getWorkbasketSummary();
       checkPreconditionsForTransferTask(task, destinationWorkbasket, originWorkbasket);
+
+      if (beforeTransferTaskManager.isEnabled()) {
+        Workbasket destinationWorkbasketFull =
+            workbasketService.getWorkbasket(destinationWorkbasket.getId());
+        beforeTransferTaskManager.checkTransferAllowed(task, destinationWorkbasketFull);
+      }
 
       applyTransferValuesForTask(task, destinationWorkbasket, owner, setTransferFlag);
       taskMapper.update(task);
@@ -238,12 +258,52 @@ final class TaskTransferrer {
                   () -> taskService.createTaskQuery().idIn(taskIds.toArray(new String[0])).list());
       taskSummaries =
           filterOutTasksWhichDoNotMatchTransferCriteria(taskIds, taskSummaries, bulkLog);
+
+      if (beforeTransferTaskManager.isEnabled()) {
+        BulkOperationResults<String, KadaiException> spiErrors =
+            checkTransferAllowedForBulk(taskSummaries, destinationWorkbasket);
+        if (spiErrors.containsErrors()) {
+          LOGGER.warn(
+              "BeforeTransferTaskProvider denied transfer for {} task(s). "
+                  + "No tasks will be transferred.",
+              spiErrors.getFailedIds().size());
+          bulkLog.addAllErrors(spiErrors);
+          return bulkLog;
+        }
+      }
+
       updateTransferableTasks(taskSummaries, destinationWorkbasket, owner, setTransferFlag);
 
       return bulkLog;
     } finally {
       kadaiEngine.returnConnection();
     }
+  }
+
+  private BulkOperationResults<String, KadaiException> checkTransferAllowedForBulk(
+      List<TaskSummary> taskSummaries, WorkbasketSummary destinationWorkbasket) {
+    BulkOperationResults<String, KadaiException> spiErrors = new BulkOperationResults<>();
+    Workbasket destinationWorkbasketFull;
+    try {
+      destinationWorkbasketFull = workbasketService.getWorkbasket(destinationWorkbasket.getId());
+    } catch (KadaiException e) {
+      LOGGER.warn("Could not load destination workbasket for SPI check", e);
+      for (TaskSummary taskSummary : taskSummaries) {
+        spiErrors.addError(taskSummary.getId(), e);
+      }
+      return spiErrors;
+    }
+    for (TaskSummary taskSummary : taskSummaries) {
+      try {
+        Task task = taskService.getTask(taskSummary.getId());
+        beforeTransferTaskManager.checkTransferAllowed(task, destinationWorkbasketFull);
+      } catch (KadaiException e) {
+        spiErrors.addError(taskSummary.getId(), e);
+      } catch (Exception e) {
+        LOGGER.error("Error loading task '{}' for SPI check", taskSummary.getId(), e);
+      }
+    }
+    return spiErrors;
   }
 
   private void checkPreconditionsForTransferTask(

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/util/ServiceProviderExtractor.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/util/ServiceProviderExtractor.java
@@ -27,6 +27,7 @@ import io.kadai.spi.task.api.AfterRequestChangesProvider;
 import io.kadai.spi.task.api.AfterRequestReviewProvider;
 import io.kadai.spi.task.api.BeforeRequestChangesProvider;
 import io.kadai.spi.task.api.BeforeRequestReviewProvider;
+import io.kadai.spi.task.api.BeforeTransferTaskProvider;
 import io.kadai.spi.task.api.CreateTaskPreprocessor;
 import io.kadai.spi.task.api.ReviewRequiredProvider;
 import io.kadai.spi.task.api.TaskDistributionProvider;
@@ -56,6 +57,7 @@ public class ServiceProviderExtractor {
           AfterRequestReviewProvider.class,
           BeforeRequestChangesProvider.class,
           AfterRequestChangesProvider.class,
+          BeforeTransferTaskProvider.class,
           TaskEndstatePreprocessor.class);
 
   private ServiceProviderExtractor() {

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/KadaiRestExceptionHandler.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/common/rest/KadaiRestExceptionHandler.java
@@ -49,6 +49,7 @@ import io.kadai.task.api.exceptions.ServiceLevelViolationException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskCommentNotFoundException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.user.api.exceptions.UserAlreadyExistException;
 import io.kadai.user.api.exceptions.UserNotFoundException;
 import io.kadai.workbasket.api.exceptions.NotAuthorizedOnWorkbasketException;
@@ -141,6 +142,12 @@ public class KadaiRestExceptionHandler extends ResponseEntityExceptionHandler {
   public ResponseEntity<Object> handleInvalidTaskStateException(
       InvalidTaskStateException ex, WebRequest req) {
     return handle(ex.getErrorCode(), ex, req, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(TransferCheckException.class)
+  public ResponseEntity<Object> handleTransferCheckException(
+      TransferCheckException ex, WebRequest req) {
+    return handle(ex.getErrorCode(), ex, req, HttpStatus.PRECONDITION_FAILED);
   }
 
   @ExceptionHandler(LogicalDuplicateInPayloadException.class)

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskApi.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskApi.java
@@ -34,6 +34,7 @@ import io.kadai.task.api.exceptions.ReopenTaskWithCallbackException;
 import io.kadai.task.api.exceptions.ServiceLevelViolationException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.task.api.models.TaskSummary;
 import io.kadai.task.rest.models.BulkOperationResultsRepresentationModel;
 import io.kadai.task.rest.models.DistributionTasksRepresentationModel;
@@ -1281,6 +1282,7 @@ public interface TaskApi {
    * @throws NotAuthorizedOnWorkbasketException if the current user has no authorization to transfer
    *     the Task.
    * @throws InvalidTaskStateException if the Task is in a state which does not allow transferring.
+   * @throws TransferCheckException if the transfer is denied
    */
   @Operation(
       summary = "Transfer a Task to another Workbasket",
@@ -1344,6 +1346,12 @@ public interface TaskApi {
                   schema =
                       @Schema(
                           anyOf = {WorkbasketNotFoundException.class, TaskNotFoundException.class}))
+            }),
+        @ApiResponse(
+            responseCode = "412",
+            description = "TASK_TRANSFER_CHECK_FAILED",
+            content = {
+              @Content(schema = @Schema(implementation = TransferCheckException.class))
             })
       })
   @PostMapping(path = RestEndpoints.URL_TASKS_ID_TRANSFER_WORKBASKET_ID)
@@ -1356,7 +1364,8 @@ public interface TaskApi {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException;
+          InvalidTaskStateException,
+          TransferCheckException;
 
   /**
    * This endpoint transfers a list of Tasks listed in the body to a given Workbasket, if possible.

--- a/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskController.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskController.java
@@ -42,6 +42,7 @@ import io.kadai.task.api.exceptions.ReopenTaskWithCallbackException;
 import io.kadai.task.api.exceptions.ServiceLevelViolationException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import io.kadai.task.rest.assembler.BulkOperationResultsRepresentationModelAssembler;
@@ -475,7 +476,8 @@ public class TaskController implements TaskApi {
       throws TaskNotFoundException,
           WorkbasketNotFoundException,
           NotAuthorizedOnWorkbasketException,
-          InvalidTaskStateException {
+          InvalidTaskStateException,
+          TransferCheckException {
     Task updatedTask;
     if (transferTaskRepresentationModel == null) {
       updatedTask = taskService.transfer(taskId, workbasketId);

--- a/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ExceptionErrorKeyTest.java
+++ b/rest/kadai-rest-spring/src/test/java/io/kadai/common/rest/ExceptionErrorKeyTest.java
@@ -46,6 +46,7 @@ import io.kadai.task.api.exceptions.ReopenTaskWithCallbackException;
 import io.kadai.task.api.exceptions.TaskAlreadyExistException;
 import io.kadai.task.api.exceptions.TaskCommentNotFoundException;
 import io.kadai.task.api.exceptions.TaskNotFoundException;
+import io.kadai.task.api.exceptions.TransferCheckException;
 import io.kadai.user.api.exceptions.UserAlreadyExistException;
 import io.kadai.user.api.exceptions.UserNotFoundException;
 import io.kadai.workbasket.api.exceptions.NotAuthorizedOnWorkbasketException;
@@ -113,6 +114,7 @@ class ExceptionErrorKeyTest {
     assertThat(TaskAlreadyExistException.ERROR_KEY).isEqualTo("TASK_ALREADY_EXISTS");
     assertThat(TaskCommentNotFoundException.ERROR_KEY).isEqualTo("TASK_COMMENT_NOT_FOUND");
     assertThat(TaskNotFoundException.ERROR_KEY).isEqualTo("TASK_NOT_FOUND");
+    assertThat(TransferCheckException.ERROR_KEY).isEqualTo("TASK_TRANSFER_CHECK_FAILED");
     assertThat(ReopenTaskWithCallbackException.ERROR_KEY).isEqualTo("REOPEN_TASK_WITH_CALLBACK");
   }
 


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it: https://github.com/kadai-io/kadai-doc/pull/194
- [x] If extra release-notes are required, they're listed indented below: