### PR TITLE
Closes #1806 - Add missing field `due` to request-body example for `PATCH /api/v1/tasks/bulkupdate`

### DIFF
--- a/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskApi.java
+++ b/rest/kadai-rest-spring/src/main/java/io/kadai/task/rest/TaskApi.java
@@ -1875,6 +1875,7 @@ public interface TaskApi {
                                       "modified": "2024-01-04T13:00:00.000Z",
                                       "planned": "2024-01-05T14:00:00.000Z",
                                       "received": "2024-01-06T15:00:00.000Z",
+                                      "due": "2024-01-06T16:00:00.000Z",
                                       "name": "Bulk Updated Task",
                                       "creator": "bulk-updater",
                                       "note": "Bulk update note",


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: