### PR TITLE
Closes #1883 - Extend `TaskCleanupJobAccTest` with 2Mio tasks load-tests

### DIFF
--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -34,9 +34,13 @@ import io.kadai.testapi.KadaiConfigurationModifier;
 import io.kadai.testapi.KadaiInject;
 import io.kadai.testapi.KadaiIntegrationTest;
 import io.kadai.testapi.builder.TaskBuilder;
+import io.kadai.testapi.generator.TaskTestDataGenerator;
 import io.kadai.testapi.security.WithAccessId;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -45,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -56,6 +61,10 @@ import org.junit.jupiter.api.function.ThrowingConsumer;
 // All tests are executed as admin, because the jobrunner needs admin rights.
 @KadaiIntegrationTest
 class TaskCleanupJobAccTest {
+
+  private static final long LOAD_TEST_TASK_COUNT = 2_000_000L;
+  private static final int LOAD_TEST_BATCH_SIZE = 10_000;
+  private static final int LOAD_TEST_TASKS_PER_PARENT_BUSINESS_PROCESS_ID = 10;
 
   @KadaiInject TaskService taskService;
   @KadaiInject WorkbasketService workbasketService;
@@ -80,7 +89,7 @@ class TaskCleanupJobAccTest {
         .primaryObjRef(primaryObjRef);
   }
 
-  private List<TaskSummary> tasksForWorkbasket(WorkbasketSummary workbasket) throws Exception {
+  private List<TaskSummary> tasksForWorkbasket(WorkbasketSummary workbasket) {
     return taskService.createTaskQuery().list().stream()
         .filter(t -> t.getWorkbasketSummary().equals(workbasket))
         .toList();
@@ -88,6 +97,40 @@ class TaskCleanupJobAccTest {
 
   private void runTaskCleanupJob(KadaiEngine kadaiEngine) throws Exception {
     new TaskCleanupJob(kadaiEngine, null, null).run();
+  }
+
+  private void createCompletedTasksForLoadTest(
+      KadaiEngine kadaiEngine, WorkbasketSummary workbasket, boolean assignParentBusinessProcessIds)
+      throws Exception {
+    TaskTestDataGenerator.from(kadaiEngine)
+        .persistCompletedTasksForCleanupLoadTest(
+            LOAD_TEST_TASK_COUNT,
+            LOAD_TEST_BATCH_SIZE,
+            classification,
+            workbasket,
+            primaryObjRef,
+            assignParentBusinessProcessIds ? LOAD_TEST_TASKS_PER_PARENT_BUSINESS_PROCESS_ID : 0);
+  }
+
+  private long countTasksForWorkbasket(KadaiEngine kadaiEngine, WorkbasketSummary workbasket)
+      throws Exception {
+    try (Connection connection = kadaiEngine.getConfiguration().getDataSource().getConnection()) {
+      setSchema(connection, kadaiEngine.getConfiguration().getSchemaName());
+      try (PreparedStatement statement =
+          connection.prepareStatement("SELECT COUNT(*) FROM TASK WHERE WORKBASKET_ID = ?")) {
+        statement.setString(1, workbasket.getId());
+        try (var resultSet = statement.executeQuery()) {
+          resultSet.next();
+          return resultSet.getLong(1);
+        }
+      }
+    }
+  }
+
+  private static void setSchema(Connection connection, String schemaName) throws SQLException {
+    if (schemaName != null && !schemaName.isBlank()) {
+      connection.setSchema(schemaName);
+    }
   }
 
   @Nested
@@ -566,6 +609,66 @@ class TaskCleanupJobAccTest {
                 .doesNotContain(taskSummaryCompleted);
           };
       return DynamicTest.stream(iterator, c -> "for parentBusinessProcessId = '" + c + "'", test);
+    }
+  }
+
+  @Disabled("Local load test only")
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class LoadTestCleanCompletedTasks implements KadaiConfigurationModifier {
+
+    @KadaiInject KadaiEngine kadaiEngine;
+
+    @Override
+    public Builder modify(Builder builder) {
+      return builder
+          .taskCleanupJobEnabled(true)
+          .jobFirstRun(Instant.now().minus(10, ChronoUnit.MILLIS))
+          .jobRunEvery(Duration.ofMillis(1))
+          .taskCleanupJobMinimumAge(Duration.ofDays(5))
+          .taskCleanupJobAllCompletedSameParentBusiness(false);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_CleanCompletedTasks_When_GroupConstraintIsDisabled() throws Exception {
+      WorkbasketSummary workbasket =
+          DefaultTestEntities.defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService);
+      createCompletedTasksForLoadTest(kadaiEngine, workbasket, false);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(countTasksForWorkbasket(kadaiEngine, workbasket)).isZero();
+    }
+  }
+
+  @Disabled("Local load test only")
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class LoadTestCleanCompletedTasksWithBusinessProcessId implements KadaiConfigurationModifier {
+
+    @KadaiInject KadaiEngine kadaiEngine;
+
+    @Override
+    public Builder modify(Builder builder) {
+      return builder
+          .taskCleanupJobEnabled(true)
+          .jobFirstRun(Instant.now().minus(10, ChronoUnit.MILLIS))
+          .jobRunEvery(Duration.ofMillis(1))
+          .taskCleanupJobMinimumAge(Duration.ofDays(5))
+          .taskCleanupJobAllCompletedSameParentBusiness(true);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_CleanCompletedTasks_When_GroupConstraintIsEnabled() throws Exception {
+      WorkbasketSummary workbasket =
+          DefaultTestEntities.defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService);
+      createCompletedTasksForLoadTest(kadaiEngine, workbasket, true);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(countTasksForWorkbasket(kadaiEngine, workbasket)).isZero();
     }
   }
 }

--- a/lib/kadai-test-api/src/main/java/io/kadai/testapi/generator/TaskTestDataGenerator.java
+++ b/lib/kadai-test-api/src/main/java/io/kadai/testapi/generator/TaskTestDataGenerator.java
@@ -80,6 +80,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.TimeZone;
+import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -395,44 +396,47 @@ public final class TaskTestDataGenerator {
    * for the transaction. Other databases use a prepared-statement batch insert fallback.
    */
   public GenerationSummary persist(long numberOfTasks, int batchSize) {
-    if (kadaiEngine == null) {
-      throw new TestDataGenerationException(
-          "Persisting tasks requires a generator created via TaskTestDataGenerator.from(...)"
-              + " so that a KadaiEngine is available");
+    return persistGeneratedTasks(numberOfTasks, batchSize, this::generateTask);
+  }
+
+  /**
+   * Persists completed tasks for cleanup-job load tests.
+   *
+   * @param numberOfTasks the number of tasks to persist
+   * @param batchSize the maximum number of tasks per database batch or PostgreSQL COPY buffer
+   * @param classification classification assigned to each generated task
+   * @param workbasket workbasket assigned to each generated task
+   * @param primaryObjRef primary object reference assigned to each generated task
+   * @param parentBusinessProcessIdGroupSize number of tasks sharing one parent business process id;
+   *     use {@code 0} to persist tasks without a parent business process id
+   * @return summary of the persistence run
+   */
+  public GenerationSummary persistCompletedTasksForCleanupLoadTest(
+      long numberOfTasks,
+      int batchSize,
+      ClassificationSummary classification,
+      WorkbasketSummary workbasket,
+      ObjectReference primaryObjRef,
+      int parentBusinessProcessIdGroupSize) {
+    Objects.requireNonNull(classification, "classification must not be null");
+    Objects.requireNonNull(workbasket, "workbasket must not be null");
+    Objects.requireNonNull(primaryObjRef, "primaryObjRef must not be null");
+    if (parentBusinessProcessIdGroupSize < 0) {
+      throw new IllegalArgumentException("parentBusinessProcessIdGroupSize must not be negative");
     }
 
-    validateTaskCount(numberOfTasks);
-    validateBatchSize(batchSize);
-
-    if (numberOfTasks == 0) {
-      return new GenerationSummary(
-          0, 0, 0, environment.classifications().size(), environment.workbaskets().size());
-    }
-
-    Connection connection = null;
-    try {
-      connection = kadaiEngine.getConfiguration().getDataSource().getConnection();
-      connection.setAutoCommit(false);
-      setSchema(connection, kadaiEngine.getConfiguration().getSchemaName());
-
-      boolean postgreSql = isPostgreSql(connection);
-      CopyManager copyManager = postgreSql ? getPostgreSqlCopyManager(connection) : null;
-      if (postgreSql) {
-        tunePostgreSqlSession(connection);
-      }
-
-      GenerationSummary summary =
-          copyManager != null
-              ? persistWithPostgreSqlCopy(numberOfTasks, batchSize, copyManager)
-              : persistWithJdbcBatch(numberOfTasks, batchSize, connection);
-      connection.commit();
-      return summary;
-    } catch (Exception ex) {
-      rollbackQuietly(connection);
-      throw new TestDataGenerationException("Task persistence failed", ex);
-    } finally {
-      closeQuietly(connection);
-    }
+    Instant completed = clock.instant().minus(Duration.ofDays(10));
+    return persistGeneratedTasks(
+        numberOfTasks,
+        batchSize,
+        index ->
+            generateCompletedTaskForCleanupLoadTest(
+                index,
+                completed,
+                classification,
+                workbasket,
+                primaryObjRef,
+                parentBusinessProcessIdGroupSize));
   }
 
   @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
@@ -549,14 +553,108 @@ public final class TaskTestDataGenerator {
     return task;
   }
 
+  private GenerationSummary persistGeneratedTasks(
+      long numberOfTasks, int batchSize, LongFunction<Task> taskFactory) {
+    if (kadaiEngine == null) {
+      throw new TestDataGenerationException(
+          "Persisting tasks requires a generator created via TaskTestDataGenerator.from(...)"
+              + " so that a KadaiEngine is available");
+    }
+
+    validateTaskCount(numberOfTasks);
+    validateBatchSize(batchSize);
+
+    if (numberOfTasks == 0) {
+      return new GenerationSummary(
+          0, 0, 0, environment.classifications().size(), environment.workbaskets().size());
+    }
+
+    Connection connection = null;
+    try {
+      connection = kadaiEngine.getConfiguration().getDataSource().getConnection();
+      connection.setAutoCommit(false);
+      setSchema(connection, kadaiEngine.getConfiguration().getSchemaName());
+
+      boolean postgreSql = isPostgreSql(connection);
+      CopyManager copyManager = postgreSql ? getPostgreSqlCopyManager(connection) : null;
+      if (postgreSql) {
+        tunePostgreSqlSession(connection);
+      }
+
+      GenerationSummary summary =
+          copyManager != null
+              ? persistWithPostgreSqlCopy(numberOfTasks, batchSize, copyManager, taskFactory)
+              : persistWithJdbcBatch(numberOfTasks, batchSize, connection, taskFactory);
+      connection.commit();
+      return summary;
+    } catch (Exception ex) {
+      rollbackQuietly(connection);
+      throw new TestDataGenerationException("Task persistence failed", ex);
+    } finally {
+      closeQuietly(connection);
+    }
+  }
+
+  private Task generateCompletedTaskForCleanupLoadTest(
+      long index,
+      Instant completed,
+      ClassificationSummary classification,
+      WorkbasketSummary workbasket,
+      ObjectReference primaryObjRef,
+      int parentBusinessProcessIdGroupSize) {
+    GeneratedTaskImpl task = (GeneratedTaskImpl) generateTask(index);
+    Instant created = completed.minus(Duration.ofDays(1));
+    task.setId(formatLoadTestIdentifier(IdGenerator.ID_PREFIX_TASK, index));
+    task.setExternalId(formatLoadTestIdentifier(IdGenerator.ID_PREFIX_EXT_TASK, index));
+    task.setCreatedIgnoreFreeze(created);
+    task.freezeCreated();
+    task.setClaimed(created.plus(Duration.ofHours(1)));
+    task.setCompleted(completed);
+    task.setModifiedIgnoreFreeze(completed);
+    task.freezeModified();
+    task.setPlanned(created);
+    task.setDue(completed.plus(Duration.ofDays(1)));
+    task.setName("TaskCleanupJob load test task");
+    task.setCreator("admin");
+    task.setDescription(null);
+    task.setNote(null);
+    task.setPriorityIgnoreFreeze(classification.getPriority());
+    task.freezePriority();
+    task.setManualPriority(-1);
+    task.setStateIgnoreFreeze(TaskState.COMPLETED);
+    task.freezeState();
+    task.setClassificationSummary(classification);
+    task.setWorkbasketSummary(workbasket);
+    task.setBusinessProcessId(
+        formatLoadTestIdentifier(IdGenerator.ID_PREFIX_BUSINESS_PROCESS, index));
+    task.setParentBusinessProcessId(
+        parentBusinessProcessIdGroupSize == 0
+            ? null
+            : formatLoadTestIdentifier("PBI", index / parentBusinessProcessIdGroupSize));
+    task.setOwner("admin");
+    task.setPrimaryObjRef(primaryObjRef);
+    task.setReadIgnoreFreeze(false);
+    task.freezeRead();
+    task.setTransferredIgnoreFreeze(false);
+    task.freezeTransferred();
+    task.setReopenedIgnoreFreeze(false);
+    task.freezeReopened();
+    task.setCallbackInfo(null);
+    task.setCallbackState(CallbackState.NONE);
+    task.setNumberOfComments(0);
+    return task;
+  }
+
   private GenerationSummary persistWithPostgreSqlCopy(
-      long numberOfTasks, int batchSize, CopyManager copyManager) throws SQLException, IOException {
+      long numberOfTasks, int batchSize, CopyManager copyManager, LongFunction<Task> taskFactory)
+      throws SQLException, IOException {
     StringBuilder buffer = new StringBuilder(estimateCopyBufferCapacity(batchSize));
     long emittedTaskCount = 0;
     long emittedBatchCount = 0;
 
     for (long index = 0; index < numberOfTasks; index++) {
-      appendTaskAsPostgreSqlCopyRow(buffer, prepareTaskForDirectPersistence(generateTask(index)));
+      appendTaskAsPostgreSqlCopyRow(
+          buffer, prepareTaskForDirectPersistence(taskFactory.apply(index)));
       emittedTaskCount++;
       if (emittedTaskCount % batchSize == 0) {
         copyBatch(copyManager, buffer);
@@ -579,13 +677,14 @@ public final class TaskTestDataGenerator {
   }
 
   private GenerationSummary persistWithJdbcBatch(
-      long numberOfTasks, int batchSize, Connection connection) throws SQLException {
+      long numberOfTasks, int batchSize, Connection connection, LongFunction<Task> taskFactory)
+      throws SQLException {
     long emittedTaskCount = 0;
     long emittedBatchCount = 0;
 
     try (PreparedStatement statement = connection.prepareStatement(TASK_INSERT_SQL)) {
       for (long index = 0; index < numberOfTasks; index++) {
-        bindTask(statement, prepareTaskForDirectPersistence(generateTask(index)));
+        bindTask(statement, prepareTaskForDirectPersistence(taskFactory.apply(index)));
         statement.addBatch();
         emittedTaskCount++;
         if (emittedTaskCount % batchSize == 0) {
@@ -1512,6 +1611,10 @@ public final class TaskTestDataGenerator {
 
   private static String formatIdentifier(String prefix, long sequence) {
     return String.format("%s:%s", prefix, pad(sequence, 12));
+  }
+
+  private static String formatLoadTestIdentifier(String prefix, long sequence) {
+    return String.format("%s:L%s", prefix, pad(sequence, 35));
   }
 
   private static String pad(long value, int length) {


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: