### PR TITLE
Closes #2019 - Skip Sonar for Dependabot-authored pushes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -847,7 +847,7 @@ jobs:
     name: Upload SonarQube analysis to sonarcloud
     needs: [ detect_changes, test_frontend, test_e2e, test_backend ]
     # Runs on every push to main and on PRs originating from kadai-io/kadai (not forks).
-    # Skipped for release tags, dependabot PRs, and if any test job failed.
+    # Skipped for release tags, dependabot PRs, dependabot-authored pushes, and if any test job failed.
     if: |
       always() &&
       github.repository == 'kadai-io/kadai' &&
@@ -855,6 +855,10 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository ) &&
       !startsWith(github.ref, 'refs/tags') &&
       !startsWith(github.head_ref || github.ref_name, 'dependabot/') &&
+      !(
+        github.event_name == 'push' &&
+        github.event.head_commit.author.name == 'dependabot[bot]'
+      ) &&
       needs.detect_changes.outputs.code_changed == 'true' &&
       needs.test_frontend.result != 'failure' &&
       needs.test_e2e.result != 'failure' &&


### PR DESCRIPTION
## What changed
- Skip the SonarQube upload job for push events where the pushed head commit is authored by `dependabot[bot]`.
- Keep the existing skip behavior for Dependabot PR branches and forks.

## Why
The previous fix skipped Dependabot PR branches, but SonarCloud still runs after those PRs are merged into `master`. On those post-merge push runs, `github.head_ref || github.ref_name` resolves to `master`, and `github.actor` can be the maintainer who merged the PR. The reliable signal in the failing runs is `github.event.head_commit.author.name == 'dependabot[bot]'`.

Observed failing SonarCloud checks:
- Backend dependency merge: https://github.com/kadai-io/kadai/runs/89149416357
- Frontend dependency merge: https://github.com/kadai-io/kadai/runs/89405641381

## Validation
- Parsed `.github/workflows/continuous-integration.yml` as YAML.
- Ran `actionlint` against the workflow, ignoring the unrelated pre-existing tag glob warning on `v[0-9]+\.[0-9]+\.[0-9]+`.
- Ran `git diff --check`.
