### PR TITLE
Closes #2074 - Fix Select-and-Claim fails on read of tasks with EDITTASKS

### DIFF
--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -356,17 +356,20 @@ public class TaskQuerySqlProvider {
         + "<choose>"
         + "<when test=\"_databaseId == 'db2'\">"
         + "SELECT WORKBASKET_ID as WID, MAX(PERM_READ) as MAX_READ, "
-        + "MAX(PERM_READTASKS) as MAX_READTASKS "
+        + "MAX(PERM_READTASKS) as MAX_READTASKS, "
+        + "MAX(PERM_EDITTASKS) as MAX_EDITTASKS "
         + "</when>"
         + "<otherwise>"
         + "SELECT WORKBASKET_ID as WID, MAX(PERM_READ::int) as MAX_READ, "
-        + "MAX(PERM_READTASKS::int) as MAX_READTASKS "
+        + "MAX(PERM_READTASKS::int) as MAX_READTASKS, "
+        + "MAX(PERM_EDITTASKS::int) as MAX_EDITTASKS "
         + "</otherwise>"
         + "</choose>"
         + "FROM WORKBASKET_ACCESS_LIST s where ACCESS_ID IN "
         + "(<foreach item='item' collection='accessIdIn' separator=',' >#{item}</foreach>) "
         + "GROUP by WORKBASKET_ID) f "
-        + "WHERE MAX_READ = 1 AND MAX_READTASKS = 1) "
+        + "WHERE MAX_READ = 1 AND MAX_READTASKS = 1 "
+        + "<if test='selectAndClaim == true'>AND MAX_EDITTASKS = 1 </if>) "
         + "</if>";
   }
 

--- a/lib/kadai-core/src/test/java/acceptance/task/claim/SelectAndClaimTaskAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/claim/SelectAndClaimTaskAccTest.java
@@ -63,9 +63,11 @@ class SelectAndClaimTaskAccTest extends AbstractAccTest {
   Workbasket wbWithoutRead;
   Workbasket wbWithoutReadTasks;
   Workbasket wbWithoutEditTasks;
+  Workbasket wbWithAllPermissions;
   Task task1;
   Task task2;
   Task task3;
+  Task task4;
 
   @WithAccessId(user = "admin")
   @BeforeAll
@@ -73,14 +75,17 @@ class SelectAndClaimTaskAccTest extends AbstractAccTest {
     wbWithoutRead = createWorkBasket();
     wbWithoutReadTasks = createWorkBasket();
     wbWithoutEditTasks = createWorkBasket();
+    wbWithAllPermissions = createWorkBasket();
 
     createWorkbasketAccessItem(wbWithoutRead, WorkbasketPermission.READ);
     createWorkbasketAccessItem(wbWithoutReadTasks, WorkbasketPermission.READTASKS);
     createWorkbasketAccessItem(wbWithoutEditTasks, WorkbasketPermission.EDITTASKS);
+    createWorkbasketAccessItemWithAllPermissions(wbWithAllPermissions);
 
     task3 = createTask(wbWithoutEditTasks);
     task1 = createTask(wbWithoutRead);
     task2 = createTask(wbWithoutReadTasks);
+    task4 = createTask(wbWithAllPermissions);
   }
 
   @Test
@@ -132,6 +137,22 @@ class SelectAndClaimTaskAccTest extends AbstractAccTest {
     TaskQuery query = kadaiEngine.getTaskService().createTaskQuery().idIn("notexisting");
     Optional<Task> task = kadaiEngine.getTaskService().selectAndClaim(query);
     assertThat(task).isEmpty();
+  }
+
+  @WithAccessId(user = "user-1-2")
+  @Test
+  void should_SelectNextClaimableTask_When_FirstReturnedTaskIsNotEditable() throws Exception {
+    TaskQuery query =
+        taskService
+            .createTaskQuery()
+            .idIn(task3.getId(), task4.getId())
+            .orderByTaskId(SortDirection.ASCENDING);
+
+    Optional<Task> selectedAndClaimedTask = taskService.selectAndClaim(query);
+
+    assertThat(selectedAndClaimedTask).isPresent();
+    assertThat(selectedAndClaimedTask.get().getId()).isEqualTo(task4.getId());
+    assertThat(selectedAndClaimedTask.get().getOwner()).isEqualTo("user-1-2");
   }
 
   private Runnable getRunnableTest(List<Task> selectedAndClaimedTasks, List<String> accessIds)
@@ -186,6 +207,17 @@ class SelectAndClaimTaskAccTest extends AbstractAccTest {
       wbai.setPermission(WorkbasketPermission.READ, true);
       wbai.setPermission(WorkbasketPermission.READTASKS, true);
     }
+    workbasketService.createWorkbasketAccessItem(wbai);
+  }
+
+  private void createWorkbasketAccessItemWithAllPermissions(Workbasket workbasket)
+      throws Exception {
+    WorkbasketService workbasketService = kadaiEngine.getWorkbasketService();
+    WorkbasketAccessItem wbai =
+        workbasketService.newWorkbasketAccessItem(workbasket.getId(), "user-1-2");
+    wbai.setPermission(WorkbasketPermission.READ, true);
+    wbai.setPermission(WorkbasketPermission.READTASKS, true);
+    wbai.setPermission(WorkbasketPermission.EDITTASKS, true);
     workbasketService.createWorkbasketAccessItem(wbai);
   }
 


### PR DESCRIPTION
Bug was a mismatch between “can see a task” and “can claim a task”.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: