### PR TITLE
Closes #2163 - Configure minimum-age per Domain

### DIFF
--- a/common/kadai-common/src/main/java/io/kadai/common/internal/configuration/parser/MapPropertyParser.java
+++ b/common/kadai-common/src/main/java/io/kadai/common/internal/configuration/parser/MapPropertyParser.java
@@ -54,13 +54,14 @@ public class MapPropertyParser implements PropertyParser<Map<?, ?>> {
 
     // Parses property files into a Map using the following layout: <Property>.<Key> = <value>
     String propertyKey = kadaiProperty.value();
+    String propertyPrefix = propertyKey + ".";
     Map<?, ?> mapFromProperties =
         properties.keySet().stream()
-            .filter(it -> it.startsWith(propertyKey))
+            .filter(it -> it.startsWith(propertyPrefix))
             .map(
                 it -> {
                   // Keys of the map entry is everything after the propertyKey + "."
-                  String rawKey = it.substring(propertyKey.length() + 1);
+                  String rawKey = it.substring(propertyPrefix.length());
                   // key is always present. filter guarantees that.
                   @SuppressWarnings("OptionalGetWithoutIsPresent")
                   Object key =

--- a/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -961,6 +962,88 @@ class KadaiConfigurationTest {
                       .build())
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_B");
+    }
+
+    @Test
+    void should_RejectNullTaskCleanupJobMinimumAgeByDomain() {
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .taskCleanupJobMinimumAgeByDomain(null)
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class)
+          .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain");
+    }
+
+    @Test
+    void should_RejectNullDomainInTaskCleanupJobMinimumAgeByDomain() {
+      Map<String, Duration> overrides = new HashMap<>();
+      overrides.put(null, Duration.ofDays(1));
+
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .taskCleanupJobMinimumAgeByDomain(overrides)
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class);
+    }
+
+    @Test
+    void should_RejectBlankDomainInTaskCleanupJobMinimumAgeByDomain() {
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .taskCleanupJobMinimumAgeByDomain(Map.of("   ", Duration.ofDays(1)))
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class);
+    }
+
+    @Test
+    void should_RejectDuplicateNormalizedDomainsInTaskCleanupJobMinimumAgeByDomain() {
+      Map<String, Duration> overrides = new LinkedHashMap<>();
+      overrides.put("domain_a", Duration.ofDays(7));
+      overrides.put("DOMAIN_A", Duration.ofDays(8));
+
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .domains(List.of("DOMAIN_A"))
+                      .taskCleanupJobMinimumAgeByDomain(overrides)
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class)
+          .hasMessageContaining("duplicate domains after normalization: DOMAIN_A");
+    }
+
+    @Test
+    void should_RejectNullDurationInTaskCleanupJobMinimumAgeByDomain() {
+      Map<String, Duration> overrides = new HashMap<>();
+      overrides.put("DOMAIN_A", null);
+
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .domains(List.of("DOMAIN_A"))
+                      .taskCleanupJobMinimumAgeByDomain(overrides)
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class)
+          .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_A");
+    }
+
+    @Test
+    void should_RejectNegativeDurationInTaskCleanupJobMinimumAgeByDomain() {
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .domains(List.of("DOMAIN_A"))
+                      .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_A", Duration.ofDays(-1)))
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class);
     }
 
     @ParameterizedTest

--- a/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
@@ -143,6 +143,13 @@ class KadaiConfigurationTest {
       assertThat(configuration.isTaskCleanupJobEnabled()).isTrue();
       assertThat(configuration.getTaskCleanupJobBatchSize()).isEqualTo(5_000);
       assertThat(configuration.getTaskCleanupJobMinimumAge()).isEqualTo(Duration.ofDays(14));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeByDomain()).isEmpty();
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain("DOMAIN_A"))
+          .isEqualTo(Duration.ofDays(14));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain(null))
+          .isEqualTo(Duration.ofDays(14));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain(MASTER_DOMAIN))
+          .isEqualTo(Duration.ofDays(14));
       assertThat(configuration.isTaskCleanupJobAllCompletedSameParentBusiness()).isTrue();
       assertThat(configuration.isWorkbasketCleanupJobEnabled()).isTrue();
       assertThat(configuration.isSimpleHistoryCleanupJobEnabled()).isFalse();
@@ -216,6 +223,12 @@ class KadaiConfigurationTest {
       assertThat(configuration.getJobRunEvery()).isEqualTo(Duration.ofDays(2));
       assertThat(configuration.isTaskCleanupJobEnabled()).isFalse();
       assertThat(configuration.getTaskCleanupJobMinimumAge()).isEqualTo(Duration.ofDays(15));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeByDomain())
+          .isEqualTo(Map.of("DOMAIN_A", Duration.ofDays(8)));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain("domain_a"))
+          .isEqualTo(Duration.ofDays(8));
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain("DOMAIN_B"))
+          .isEqualTo(Duration.ofDays(15));
       assertThat(configuration.isTaskCleanupJobAllCompletedSameParentBusiness()).isFalse();
       assertThat(configuration.isWorkbasketCleanupJobEnabled()).isFalse();
       assertThat(configuration.isSimpleHistoryCleanupJobEnabled()).isTrue();
@@ -293,6 +306,8 @@ class KadaiConfigurationTest {
       boolean expectedTaskCleanupJobEnabled = false;
       int expectedTaskCleanupJobBatchSize = 5_001;
       Duration expectedTaskCleanupJobMinimumAge = Duration.ofDays(1);
+      Map<String, Duration> expectedTaskCleanupJobMinimumAgeByDomain =
+          Map.of("A", Duration.ofHours(1));
       boolean expectedTaskCleanupJobAllCompletedSameParentBusiness = false;
       Duration expectedTaskCleanupJobLockExpirationPeriod = Duration.ofDays(2);
       boolean expectedWorkbasketCleanupJobEnabled = false;
@@ -360,6 +375,7 @@ class KadaiConfigurationTest {
               .taskCleanupJobEnabled(expectedTaskCleanupJobEnabled)
               .taskCleanupJobBatchSize(expectedTaskCleanupJobBatchSize)
               .taskCleanupJobMinimumAge(expectedTaskCleanupJobMinimumAge)
+              .taskCleanupJobMinimumAgeByDomain(expectedTaskCleanupJobMinimumAgeByDomain)
               .taskCleanupJobAllCompletedSameParentBusiness(
                   expectedTaskCleanupJobAllCompletedSameParentBusiness)
               .taskCleanupJobLockExpirationPeriod(expectedTaskCleanupJobLockExpirationPeriod)
@@ -439,6 +455,10 @@ class KadaiConfigurationTest {
           .isEqualTo(expectedTaskCleanupJobBatchSize);
       assertThat(configuration.getTaskCleanupJobMinimumAge())
           .isEqualTo(expectedTaskCleanupJobMinimumAge);
+      assertThat(configuration.getTaskCleanupJobMinimumAgeByDomain())
+          .isEqualTo(expectedTaskCleanupJobMinimumAgeByDomain);
+      assertThat(configuration.getTaskCleanupJobMinimumAgeForDomain("A"))
+          .isEqualTo(Duration.ofHours(1));
       assertThat(configuration.isTaskCleanupJobAllCompletedSameParentBusiness())
           .isEqualTo(expectedTaskCleanupJobAllCompletedSameParentBusiness);
       assertThat(configuration.isWorkbasketCleanupJobEnabled())
@@ -513,6 +533,7 @@ class KadaiConfigurationTest {
               .taskCleanupJobEnabled(false)
               .taskCleanupJobBatchSize(5_001)
               .taskCleanupJobMinimumAge(Duration.ofDays(1))
+              .taskCleanupJobMinimumAgeByDomain(Map.of("A", Duration.ofHours(1)))
               .taskCleanupJobAllCompletedSameParentBusiness(false)
               .taskCleanupJobLockExpirationPeriod(Duration.ofDays(6))
               .workbasketCleanupJobEnabled(false)
@@ -919,6 +940,27 @@ class KadaiConfigurationTest {
           .hasMessageContaining(
               "Parameter taskCleanupJobMinimumAge (kadai.jobs.cleanup.task.minimumAge) "
                   + "must not be negative");
+    }
+
+    @Test
+    void should_ValidateTaskCleanupJobMinimumAgeByDomain() {
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .domains(List.of("DOMAIN_A"))
+              .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_A", Duration.ZERO));
+
+      assertThat(builder.build().getTaskCleanupJobMinimumAgeForDomain("domain_a"))
+          .isEqualTo(Duration.ZERO);
+      assertThatThrownBy(
+              () ->
+                  new KadaiConfiguration.Builder(
+                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+                      .domains(List.of("DOMAIN_A"))
+                      .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_B", Duration.ofDays(1)))
+                      .build())
+          .isInstanceOf(InvalidArgumentException.class)
+          .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_B");
     }
 
     @ParameterizedTest

--- a/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/KadaiConfigurationTest.java
@@ -950,28 +950,27 @@ class KadaiConfigurationTest {
                   TestContainerExtension.createDataSourceForH2(), false, "KADAI")
               .domains(List.of("DOMAIN_A"))
               .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_A", Duration.ZERO));
+      KadaiConfiguration.Builder invalidBuilder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .domains(List.of("DOMAIN_A"))
+              .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_B", Duration.ofDays(1)));
 
       assertThat(builder.build().getTaskCleanupJobMinimumAgeForDomain("domain_a"))
           .isEqualTo(Duration.ZERO);
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .domains(List.of("DOMAIN_A"))
-                      .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_B", Duration.ofDays(1)))
-                      .build())
+      assertThatThrownBy(invalidBuilder::build)
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_B");
     }
 
     @Test
     void should_RejectNullTaskCleanupJobMinimumAgeByDomain() {
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .taskCleanupJobMinimumAgeByDomain(null)
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .taskCleanupJobMinimumAgeByDomain(null);
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain");
     }
@@ -981,23 +980,23 @@ class KadaiConfigurationTest {
       Map<String, Duration> overrides = new HashMap<>();
       overrides.put(null, Duration.ofDays(1));
 
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .taskCleanupJobMinimumAgeByDomain(overrides)
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .taskCleanupJobMinimumAgeByDomain(overrides);
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class);
     }
 
     @Test
     void should_RejectBlankDomainInTaskCleanupJobMinimumAgeByDomain() {
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .taskCleanupJobMinimumAgeByDomain(Map.of("   ", Duration.ofDays(1)))
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .taskCleanupJobMinimumAgeByDomain(Map.of("   ", Duration.ofDays(1)));
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class);
     }
 
@@ -1007,13 +1006,13 @@ class KadaiConfigurationTest {
       overrides.put("domain_a", Duration.ofDays(7));
       overrides.put("DOMAIN_A", Duration.ofDays(8));
 
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .domains(List.of("DOMAIN_A"))
-                      .taskCleanupJobMinimumAgeByDomain(overrides)
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .domains(List.of("DOMAIN_A"))
+              .taskCleanupJobMinimumAgeByDomain(overrides);
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining("duplicate domains after normalization: DOMAIN_A");
     }
@@ -1023,26 +1022,26 @@ class KadaiConfigurationTest {
       Map<String, Duration> overrides = new HashMap<>();
       overrides.put("DOMAIN_A", null);
 
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .domains(List.of("DOMAIN_A"))
-                      .taskCleanupJobMinimumAgeByDomain(overrides)
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .domains(List.of("DOMAIN_A"))
+              .taskCleanupJobMinimumAgeByDomain(overrides);
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining("kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_A");
     }
 
     @Test
     void should_RejectNegativeDurationInTaskCleanupJobMinimumAgeByDomain() {
-      assertThatThrownBy(
-              () ->
-                  new KadaiConfiguration.Builder(
-                          TestContainerExtension.createDataSourceForH2(), false, "KADAI")
-                      .domains(List.of("DOMAIN_A"))
-                      .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_A", Duration.ofDays(-1)))
-                      .build())
+      KadaiConfiguration.Builder builder =
+          new KadaiConfiguration.Builder(
+                  TestContainerExtension.createDataSourceForH2(), false, "KADAI")
+              .domains(List.of("DOMAIN_A"))
+              .taskCleanupJobMinimumAgeByDomain(Map.of("DOMAIN_A", Duration.ofDays(-1)));
+
+      assertThatThrownBy(builder::build)
           .isInstanceOf(InvalidArgumentException.class);
     }
 

--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -730,7 +730,7 @@ class TaskCleanupJobAccTest {
 
     @WithAccessId(user = "admin")
     @Test
-    void should_KeepCompleteParentGroup_WhenOneDomainHasNotReachedItsMinimumAge()
+    void should_KeepCompleteParentGroup_When_OneDomainHasNotReachedItsMinimumAge()
         throws Exception {
       String parentBusinessProcessId = "DOMAIN_SPECIFIC_PARENT";
       TaskSummary domainATask =

--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -645,11 +645,12 @@ class TaskCleanupJobAccTest {
 
     WorkbasketSummary domainAWorkbasket;
     WorkbasketSummary domainBWorkbasket;
+    WorkbasketSummary domainCWorkbasket;
 
     @Override
     public Builder modify(Builder builder) {
       return builder
-          .domains(List.of("DOMAIN_A", "DOMAIN_B"))
+          .domains(List.of("DOMAIN_A", "DOMAIN_B", "DOMAIN_C"))
           .taskCleanupJobEnabled(true)
           .taskCleanupJobMinimumAge(Duration.ofDays(14))
           .taskCleanupJobMinimumAgeByDomain(
@@ -670,6 +671,11 @@ class TaskCleanupJobAccTest {
               .key("DOMAIN_B_CLEANUP")
               .domain("DOMAIN_B")
               .buildAndStoreAsSummary(workbasketService);
+      domainCWorkbasket =
+          DefaultTestEntities.defaultTestWorkbasket()
+              .key("DOMAIN_C_CLEANUP")
+              .domain("DOMAIN_C")
+              .buildAndStoreAsSummary(kadaiEngine.getWorkbasketService());
     }
 
     @WithAccessId(user = "admin")
@@ -683,13 +689,27 @@ class TaskCleanupJobAccTest {
       TaskSummary domainBTask =
           newTaskBuilder(domainBWorkbasket)
               .state(TaskState.COMPLETED)
-              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .completed(Instant.now().minus(20, ChronoUnit.DAYS))
               .buildAndStoreAsSummary(taskService);
+      final TaskSummary domainCOldTask =
+          newTaskBuilder(domainCWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(20, ChronoUnit.DAYS))
+              .buildAndStoreAsSummary(kadaiEngine.getTaskService());
+      final TaskSummary domainCRecentTask =
+          newTaskBuilder(domainCWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .buildAndStoreAsSummary(kadaiEngine.getTaskService());
 
       runTaskCleanupJob(kadaiEngine);
 
       assertThat(tasksForWorkbasket(domainAWorkbasket)).doesNotContain(domainATask);
       assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(domainBTask);
+      assertThat(kadaiEngine.getTaskService().createTaskQuery().list()).filteredOn(
+          task -> task.getWorkbasketSummary().equals(domainCWorkbasket))
+          .contains(domainCRecentTask)
+          .doesNotContain(domainCOldTask);
     }
   }
 
@@ -750,6 +770,51 @@ class TaskCleanupJobAccTest {
 
       assertThat(tasksForWorkbasket(domainAWorkbasket)).contains(domainATask);
       assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(domainBTask);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_CleanCompleteParentGroup_When_AllDomainsReachedTheirMinimumAge()
+        throws Exception {
+      String parentBusinessProcessId = "DOMAIN_SPECIFIC_ELIGIBLE_PARENT";
+      TaskSummary domainATask =
+          newTaskBuilder(domainAWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+      TaskSummary domainBTask =
+          newTaskBuilder(domainBWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(35, ChronoUnit.DAYS))
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(tasksForWorkbasket(domainAWorkbasket)).doesNotContain(domainATask);
+      assertThat(tasksForWorkbasket(domainBWorkbasket)).doesNotContain(domainBTask);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_KeepParentGroup_When_OneDomainSpecificSiblingIsIncomplete() throws Exception {
+      String parentBusinessProcessId = "DOMAIN_SPECIFIC_INCOMPLETE_PARENT";
+      TaskSummary completedDomainATask =
+          newTaskBuilder(domainAWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+      TaskSummary incompleteDomainBTask =
+          newTaskBuilder(domainBWorkbasket)
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(tasksForWorkbasket(domainAWorkbasket)).contains(completedDomainATask);
+      assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(incompleteDomainBTask);
     }
   }
 }

--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -49,6 +49,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -633,6 +634,122 @@ class TaskCleanupJobAccTest {
                 .doesNotContain(taskSummaryCompleted);
           };
       return DynamicTest.stream(iterator, c -> "for parentBusinessProcessId = '" + c + "'", test);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class DomainSpecificMinimumAge implements KadaiConfigurationModifier {
+
+    @KadaiInject KadaiEngine kadaiEngine;
+
+    WorkbasketSummary domainAWorkbasket;
+    WorkbasketSummary domainBWorkbasket;
+
+    @Override
+    public Builder modify(Builder builder) {
+      return builder
+          .domains(List.of("DOMAIN_A", "DOMAIN_B"))
+          .taskCleanupJobEnabled(true)
+          .taskCleanupJobMinimumAge(Duration.ofDays(14))
+          .taskCleanupJobMinimumAgeByDomain(
+              Map.of("DOMAIN_A", Duration.ofDays(7), "DOMAIN_B", Duration.ofDays(30)))
+          .taskCleanupJobAllCompletedSameParentBusiness(false);
+    }
+
+    @WithAccessId(user = "businessadmin")
+    @BeforeAll
+    void setup() throws Exception {
+      domainAWorkbasket =
+          DefaultTestEntities.defaultTestWorkbasket()
+              .key("DOMAIN_A_CLEANUP")
+              .domain("DOMAIN_A")
+              .buildAndStoreAsSummary(workbasketService);
+      domainBWorkbasket =
+          DefaultTestEntities.defaultTestWorkbasket()
+              .key("DOMAIN_B_CLEANUP")
+              .domain("DOMAIN_B")
+              .buildAndStoreAsSummary(workbasketService);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_ApplyDomainSpecificMinimumAgeAndFallback() throws Exception {
+      TaskSummary domainATask =
+          newTaskBuilder(domainAWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .buildAndStoreAsSummary(taskService);
+      TaskSummary domainBTask =
+          newTaskBuilder(domainBWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .buildAndStoreAsSummary(taskService);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(tasksForWorkbasket(domainAWorkbasket)).doesNotContain(domainATask);
+      assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(domainBTask);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class DomainSpecificMinimumAgeWithParentConstraint implements KadaiConfigurationModifier {
+
+    @KadaiInject KadaiEngine kadaiEngine;
+
+    WorkbasketSummary domainAWorkbasket;
+    WorkbasketSummary domainBWorkbasket;
+
+    @Override
+    public Builder modify(Builder builder) {
+      return builder
+          .domains(List.of("DOMAIN_A", "DOMAIN_B"))
+          .taskCleanupJobEnabled(true)
+          .taskCleanupJobMinimumAge(Duration.ofDays(14))
+          .taskCleanupJobMinimumAgeByDomain(
+              Map.of("DOMAIN_A", Duration.ofDays(7), "DOMAIN_B", Duration.ofDays(30)))
+          .taskCleanupJobAllCompletedSameParentBusiness(true);
+    }
+
+    @WithAccessId(user = "businessadmin")
+    @BeforeAll
+    void setup() throws Exception {
+      domainAWorkbasket =
+          DefaultTestEntities.defaultTestWorkbasket()
+              .key("DOMAIN_A_PARENT_CLEANUP")
+              .domain("DOMAIN_A")
+              .buildAndStoreAsSummary(workbasketService);
+      domainBWorkbasket =
+          DefaultTestEntities.defaultTestWorkbasket()
+              .key("DOMAIN_B_PARENT_CLEANUP")
+              .domain("DOMAIN_B")
+              .buildAndStoreAsSummary(workbasketService);
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_KeepCompleteParentGroup_WhenOneDomainHasNotReachedItsMinimumAge()
+        throws Exception {
+      String parentBusinessProcessId = "DOMAIN_SPECIFIC_PARENT";
+      TaskSummary domainATask =
+          newTaskBuilder(domainAWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(10, ChronoUnit.DAYS))
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+      TaskSummary domainBTask =
+          newTaskBuilder(domainBWorkbasket)
+              .state(TaskState.COMPLETED)
+              .completed(Instant.now().minus(20, ChronoUnit.DAYS))
+              .parentBusinessProcessId(parentBusinessProcessId)
+              .buildAndStoreAsSummary(taskService);
+
+      runTaskCleanupJob(kadaiEngine);
+
+      assertThat(tasksForWorkbasket(domainAWorkbasket)).contains(domainATask);
+      assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(domainBTask);
     }
   }
 }

--- a/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -695,19 +695,19 @@ class TaskCleanupJobAccTest {
           newTaskBuilder(domainCWorkbasket)
               .state(TaskState.COMPLETED)
               .completed(Instant.now().minus(20, ChronoUnit.DAYS))
-              .buildAndStoreAsSummary(kadaiEngine.getTaskService());
+              .buildAndStoreAsSummary(taskService);
       final TaskSummary domainCRecentTask =
           newTaskBuilder(domainCWorkbasket)
               .state(TaskState.COMPLETED)
               .completed(Instant.now().minus(10, ChronoUnit.DAYS))
-              .buildAndStoreAsSummary(kadaiEngine.getTaskService());
+              .buildAndStoreAsSummary(taskService);
 
       runTaskCleanupJob(kadaiEngine);
 
       assertThat(tasksForWorkbasket(domainAWorkbasket)).doesNotContain(domainATask);
       assertThat(tasksForWorkbasket(domainBWorkbasket)).contains(domainBTask);
-      assertThat(kadaiEngine.getTaskService().createTaskQuery().list()).filteredOn(
-          task -> task.getWorkbasketSummary().equals(domainCWorkbasket))
+      assertThat(taskService.createTaskQuery().list())
+          .filteredOn(task -> task.getWorkbasketSummary().equals(domainCWorkbasket))
           .contains(domainCRecentTask)
           .doesNotContain(domainCOldTask);
     }
@@ -774,8 +774,7 @@ class TaskCleanupJobAccTest {
 
     @WithAccessId(user = "admin")
     @Test
-    void should_CleanCompleteParentGroup_When_AllDomainsReachedTheirMinimumAge()
-        throws Exception {
+    void should_CleanCompleteParentGroup_When_AllDomainsReachedTheirMinimumAge() throws Exception {
       String parentBusinessProcessId = "DOMAIN_SPECIFIC_ELIGIBLE_PARENT";
       TaskSummary domainATask =
           newTaskBuilder(domainAWorkbasket)

--- a/lib/kadai-core-test/src/test/resources/fullKadai.properties
+++ b/lib/kadai-core-test/src/test/resources/fullKadai.properties
@@ -40,6 +40,7 @@ kadai.jobs.lockExpirationPeriod=PT7M
 kadai.jobs.cleanup.task.enable=false
 kadai.jobs.cleanup.task.batchSize=4999
 kadai.jobs.cleanup.task.minimumAge=P15D
+kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_A=P8D
 kadai.jobs.cleanup.task.allCompletedSameParentBusiness=false
 kadai.jobs.cleanup.task.lockExpirationPeriod=PT4M
 kadai.jobs.cleanup.workbasket.enable=false

--- a/lib/kadai-core-test/src/test/resources/fullKadai.properties
+++ b/lib/kadai-core-test/src/test/resources/fullKadai.properties
@@ -41,6 +41,7 @@ kadai.jobs.cleanup.task.enable=false
 kadai.jobs.cleanup.task.batchSize=4999
 kadai.jobs.cleanup.task.minimumAge=P15D
 kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_A=P8D
+kadai.jobs.cleanup.task.minimumAgeByDomainSomethingElse.DOMAIN_B=P9D
 kadai.jobs.cleanup.task.allCompletedSameParentBusiness=false
 kadai.jobs.cleanup.task.lockExpirationPeriod=PT4M
 kadai.jobs.cleanup.workbasket.enable=false

--- a/lib/kadai-core-test/src/test/resources/fullKadai.properties
+++ b/lib/kadai-core-test/src/test/resources/fullKadai.properties
@@ -41,7 +41,6 @@ kadai.jobs.cleanup.task.enable=false
 kadai.jobs.cleanup.task.batchSize=4999
 kadai.jobs.cleanup.task.minimumAge=P15D
 kadai.jobs.cleanup.task.minimumAgeByDomain.DOMAIN_A=P8D
-kadai.jobs.cleanup.task.minimumAgeByDomainSomethingElse.DOMAIN_B=P9D
 kadai.jobs.cleanup.task.allCompletedSameParentBusiness=false
 kadai.jobs.cleanup.task.lockExpirationPeriod=PT4M
 kadai.jobs.cleanup.workbasket.enable=false

--- a/lib/kadai-core/src/main/java/io/kadai/KadaiConfiguration.java
+++ b/lib/kadai-core/src/main/java/io/kadai/KadaiConfiguration.java
@@ -1508,15 +1508,9 @@ public class KadaiConfiguration {
     }
 
     private void validateTaskCleanupMinimumAgeByDomain() {
-      if (taskCleanupJobMinimumAgeByDomain == null) {
-        throw invalidTaskCleanupMinimumAgeByDomain("must not be null");
-      }
       for (Entry<String, Duration> entry : taskCleanupJobMinimumAgeByDomain.entrySet()) {
         String domain = entry.getKey();
         Duration duration = entry.getValue();
-        if (domain == null || domain.isBlank()) {
-          throw invalidTaskCleanupMinimumAgeByDomain("must not contain a null or blank domain");
-        }
         if (duration == null || duration.isNegative()) {
           throw new InvalidArgumentException(
               "Parameter taskCleanupJobMinimumAgeByDomain "

--- a/lib/kadai-core/src/main/java/io/kadai/KadaiConfiguration.java
+++ b/lib/kadai-core/src/main/java/io/kadai/KadaiConfiguration.java
@@ -120,6 +120,7 @@ public class KadaiConfiguration {
   private final boolean taskCleanupJobEnabled;
   private final int taskCleanupJobBatchSize;
   private final Duration taskCleanupJobMinimumAge;
+  private final Map<String, Duration> taskCleanupJobMinimumAgeByDomain;
   private final boolean taskCleanupJobAllCompletedSameParentBusiness;
   private final Duration taskCleanupJobLockExpirationPeriod;
 
@@ -214,6 +215,7 @@ public class KadaiConfiguration {
     this.taskCleanupJobEnabled = builder.taskCleanupJobEnabled;
     this.taskCleanupJobBatchSize = builder.taskCleanupJobBatchSize;
     this.taskCleanupJobMinimumAge = builder.taskCleanupJobMinimumAge;
+    this.taskCleanupJobMinimumAgeByDomain = Map.copyOf(builder.taskCleanupJobMinimumAgeByDomain);
     this.taskCleanupJobAllCompletedSameParentBusiness =
         builder.taskCleanupJobAllCompletedSameParentBusiness;
     this.taskCleanupJobLockExpirationPeriod = builder.taskCleanupJobLockExpirationPeriod;
@@ -380,6 +382,18 @@ public class KadaiConfiguration {
     return taskCleanupJobMinimumAge;
   }
 
+  public Map<String, Duration> getTaskCleanupJobMinimumAgeByDomain() {
+    return taskCleanupJobMinimumAgeByDomain;
+  }
+
+  public Duration getTaskCleanupJobMinimumAgeForDomain(String domain) {
+    if (domain == null || MASTER_DOMAIN.equals(domain)) {
+      return taskCleanupJobMinimumAge;
+    }
+    return taskCleanupJobMinimumAgeByDomain.getOrDefault(
+        domain.toUpperCase(), taskCleanupJobMinimumAge);
+  }
+
   public boolean isTaskCleanupJobAllCompletedSameParentBusiness() {
     return taskCleanupJobAllCompletedSameParentBusiness;
   }
@@ -523,6 +537,7 @@ public class KadaiConfiguration {
         taskCleanupJobEnabled,
         taskCleanupJobBatchSize,
         taskCleanupJobMinimumAge,
+        taskCleanupJobMinimumAgeByDomain,
         taskCleanupJobAllCompletedSameParentBusiness,
         taskCleanupJobLockExpirationPeriod,
         workbasketCleanupJobEnabled,
@@ -601,6 +616,7 @@ public class KadaiConfiguration {
         && Objects.equals(jobRunEvery, other.jobRunEvery)
         && Objects.equals(jobLockExpirationPeriod, other.jobLockExpirationPeriod)
         && Objects.equals(taskCleanupJobMinimumAge, other.taskCleanupJobMinimumAge)
+        && Objects.equals(taskCleanupJobMinimumAgeByDomain, other.taskCleanupJobMinimumAgeByDomain)
         && Objects.equals(
             taskCleanupJobLockExpirationPeriod, other.taskCleanupJobLockExpirationPeriod)
         && Objects.equals(
@@ -691,6 +707,8 @@ public class KadaiConfiguration {
         + taskCleanupJobBatchSize
         + ", taskCleanupJobMinimumAge="
         + taskCleanupJobMinimumAge
+        + ", taskCleanupJobMinimumAgeByDomain="
+        + taskCleanupJobMinimumAgeByDomain
         + ", taskCleanupJobAllCompletedSameParentBusiness="
         + taskCleanupJobAllCompletedSameParentBusiness
         + ", taskCleanupJobLockExpirationPeriod="
@@ -848,6 +866,9 @@ public class KadaiConfiguration {
 
     @KadaiProperty("kadai.jobs.cleanup.task.minimumAge")
     private Duration taskCleanupJobMinimumAge = Duration.ofDays(14);
+
+    @KadaiProperty("kadai.jobs.cleanup.task.minimumAgeByDomain")
+    private Map<String, Duration> taskCleanupJobMinimumAgeByDomain = new HashMap<>();
 
     @KadaiProperty("kadai.jobs.cleanup.task.allCompletedSameParentBusiness")
     private boolean taskCleanupJobAllCompletedSameParentBusiness = true;
@@ -1010,6 +1031,7 @@ public class KadaiConfiguration {
       this.taskCleanupJobEnabled = conf.taskCleanupJobEnabled;
       this.taskCleanupJobBatchSize = conf.taskCleanupJobBatchSize;
       this.taskCleanupJobMinimumAge = conf.taskCleanupJobMinimumAge;
+      this.taskCleanupJobMinimumAgeByDomain = conf.taskCleanupJobMinimumAgeByDomain;
       this.taskCleanupJobAllCompletedSameParentBusiness =
           conf.taskCleanupJobAllCompletedSameParentBusiness;
       this.taskCleanupJobLockExpirationPeriod = conf.taskCleanupJobLockExpirationPeriod;
@@ -1251,6 +1273,12 @@ public class KadaiConfiguration {
       return this;
     }
 
+    public Builder taskCleanupJobMinimumAgeByDomain(
+        Map<String, Duration> taskCleanupJobMinimumAgeByDomain) {
+      this.taskCleanupJobMinimumAgeByDomain = taskCleanupJobMinimumAgeByDomain;
+      return this;
+    }
+
     public Builder taskCleanupJobAllCompletedSameParentBusiness(
         boolean taskCleanupJobAllCompletedSameParentBusiness) {
       this.taskCleanupJobAllCompletedSameParentBusiness =
@@ -1429,6 +1457,7 @@ public class KadaiConfiguration {
 
     private void adjustConfiguration() {
       domains = domains.stream().map(String::toUpperCase).toList();
+      taskCleanupJobMinimumAgeByDomain = normalizeTaskCleanupMinimumAgeByDomain();
       classificationTypes = classificationTypes.stream().map(String::toUpperCase).toList();
       classificationCategoriesByType =
           classificationCategoriesByType.entrySet().stream()
@@ -1455,6 +1484,62 @@ public class KadaiConfiguration {
                               .map(String::toLowerCase)
                               .collect(Collectors.toSet())))
               .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+    }
+
+    private Map<String, Duration> normalizeTaskCleanupMinimumAgeByDomain() {
+      if (taskCleanupJobMinimumAgeByDomain == null) {
+        throw invalidTaskCleanupMinimumAgeByDomain("must not be null");
+      }
+
+      Map<String, Duration> normalizedOverrides = new LinkedHashMap<>();
+      for (Entry<String, Duration> entry : taskCleanupJobMinimumAgeByDomain.entrySet()) {
+        String domain = entry.getKey();
+        if (domain == null || domain.isBlank()) {
+          throw invalidTaskCleanupMinimumAgeByDomain("must not contain a null or blank domain");
+        }
+        String normalizedDomain = domain.toUpperCase();
+        if (normalizedOverrides.containsKey(normalizedDomain)) {
+          throw invalidTaskCleanupMinimumAgeByDomain(
+              "must not contain duplicate domains after normalization: " + normalizedDomain);
+        }
+        normalizedOverrides.put(normalizedDomain, entry.getValue());
+      }
+      return normalizedOverrides;
+    }
+
+    private void validateTaskCleanupMinimumAgeByDomain() {
+      if (taskCleanupJobMinimumAgeByDomain == null) {
+        throw invalidTaskCleanupMinimumAgeByDomain("must not be null");
+      }
+      for (Entry<String, Duration> entry : taskCleanupJobMinimumAgeByDomain.entrySet()) {
+        String domain = entry.getKey();
+        Duration duration = entry.getValue();
+        if (domain == null || domain.isBlank()) {
+          throw invalidTaskCleanupMinimumAgeByDomain("must not contain a null or blank domain");
+        }
+        if (duration == null || duration.isNegative()) {
+          throw new InvalidArgumentException(
+              "Parameter taskCleanupJobMinimumAgeByDomain "
+                  + "(kadai.jobs.cleanup.task.minimumAgeByDomain."
+                  + domain
+                  + ") must not be null or negative");
+        }
+        if (!domains.contains(domain)) {
+          throw new InvalidArgumentException(
+              "Parameter taskCleanupJobMinimumAgeByDomain "
+                  + "(kadai.jobs.cleanup.task.minimumAgeByDomain."
+                  + domain
+                  + ") refers to unknown domain "
+                  + domain);
+        }
+      }
+    }
+
+    private InvalidArgumentException invalidTaskCleanupMinimumAgeByDomain(String detail) {
+      return new InvalidArgumentException(
+          "Parameter taskCleanupJobMinimumAgeByDomain "
+              + "(kadai.jobs.cleanup.task.minimumAgeByDomain) "
+              + detail);
     }
 
     private void validateConfiguration() {
@@ -1487,6 +1572,7 @@ public class KadaiConfiguration {
             "Parameter taskCleanupJobMinimumAge "
                 + "(kadai.jobs.cleanup.task.minimumAge) must not be negative");
       }
+      validateTaskCleanupMinimumAgeByDomain();
       if (taskUpdatePriorityJobBatchSize <= 0) {
         throw new InvalidArgumentException(
             "Parameter taskUpdatePriorityJobBatchSize (kadai.jobs.priority.task.batchSize)"

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskMapper.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskMapper.java
@@ -351,6 +351,21 @@ public interface TaskMapper {
 
   @Select(
       "<script>"
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' separator=' UNION ALL '>"
+          + "SELECT t.ID FROM TASK t WHERE t.DOMAIN = #{domain} AND t.COMPLETED &lt;= #{completedBefore}"
+          + "</foreach> "
+          + "UNION ALL "
+          + "SELECT t.ID FROM TASK t WHERE (t.DOMAIN IS NULL OR t.DOMAIN NOT IN "
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' open='(' separator=',' close=')'>#{domain}</foreach>) "
+          + "AND t.COMPLETED &lt;= #{defaultCompletedBefore} "
+          + "<if test=\"_databaseId == 'db2'\">with UR </if>"
+          + "</script>")
+  List<String> findTasksCompletedBeforeByDomain(
+      @Param("defaultCompletedBefore") Instant defaultCompletedBefore,
+      @Param("completedBeforeByDomain") Map<String, Instant> completedBeforeByDomain);
+
+  @Select(
+      "<script>"
           + "WITH TASKS_WITH_PARENT_COMPLETION AS ("
           + "SELECT ID, COMPLETED, "
           + "COUNT(*) OVER (PARTITION BY PARENT_BUSINESS_PROCESS_ID) AS PARENT_TASK_COUNT, "
@@ -377,4 +392,37 @@ public interface TaskMapper {
           + "</script>")
   List<String> findTasksCompletedBeforeWithParentBusinessProcessConstraint(
       @Param("completedBefore") Instant completedBefore);
+
+  @Select(
+      "<script>"
+          + "WITH TASKS_WITH_PARENT_CLEANUP_ELIGIBILITY AS ("
+          + "SELECT t.ID, "
+          + "COUNT(*) OVER (PARTITION BY t.PARENT_BUSINESS_PROCESS_ID) AS PARENT_TASK_COUNT, "
+          + "SUM(CASE WHEN ("
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' separator=' OR '>(t.DOMAIN = #{domain} AND t.COMPLETED &lt;= #{completedBefore})</foreach> "
+          + "OR ((t.DOMAIN IS NULL OR t.DOMAIN NOT IN "
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' open='(' separator=',' close=')'>#{domain}</foreach>) "
+          + "AND t.COMPLETED &lt;= #{defaultCompletedBefore})"
+          + ") THEN 1 ELSE 0 END) OVER (PARTITION BY t.PARENT_BUSINESS_PROCESS_ID) "
+          + "AS PARENT_ELIGIBLE_TASK_COUNT "
+          + "FROM TASK t WHERE t.PARENT_BUSINESS_PROCESS_ID IS NOT NULL "
+          + "AND CHARACTER_LENGTH(t.PARENT_BUSINESS_PROCESS_ID) &gt; 0"
+          + ") "
+          + "SELECT ID FROM TASKS_WITH_PARENT_CLEANUP_ELIGIBILITY "
+          + "WHERE PARENT_TASK_COUNT = PARENT_ELIGIBLE_TASK_COUNT "
+          + "UNION ALL "
+          + "SELECT t.ID FROM TASK t "
+          + "WHERE (t.PARENT_BUSINESS_PROCESS_ID IS NULL "
+          + "OR CHARACTER_LENGTH(t.PARENT_BUSINESS_PROCESS_ID) = 0) "
+          + "AND ("
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' separator=' OR '>(t.DOMAIN = #{domain} AND t.COMPLETED &lt;= #{completedBefore})</foreach> "
+          + "OR ((t.DOMAIN IS NULL OR t.DOMAIN NOT IN "
+          + "<foreach collection='completedBeforeByDomain' index='domain' item='completedBefore' open='(' separator=',' close=')'>#{domain}</foreach>) "
+          + "AND t.COMPLETED &lt;= #{defaultCompletedBefore})"
+          + ") "
+          + "<if test=\"_databaseId == 'db2'\">with UR </if>"
+          + "</script>")
+  List<String> findTasksCompletedBeforeByDomainWithParentBusinessProcessConstraint(
+      @Param("defaultCompletedBefore") Instant defaultCompletedBefore,
+      @Param("completedBeforeByDomain") Map<String, Instant> completedBeforeByDomain);
 }

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/jobs/TaskCleanupJob.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/jobs/TaskCleanupJob.java
@@ -35,7 +35,9 @@ import io.kadai.common.internal.util.CollectionUtil;
 import io.kadai.common.internal.util.LogSanitizer;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,14 +46,16 @@ public class TaskCleanupJob extends AbstractKadaiJob {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskCleanupJob.class);
 
-  private final Duration minimumAge;
+  private final Duration defaultMinimumAge;
+  private final Map<String, Duration> minimumAgeByDomain;
   private final int batchSize;
   private final boolean allCompletedSameParentBusiness;
 
   public TaskCleanupJob(
       KadaiEngine kadaiEngine, KadaiTransactionProvider txProvider, ScheduledJob scheduledJob) {
     super(kadaiEngine, txProvider, scheduledJob, true);
-    minimumAge = kadaiEngine.getConfiguration().getTaskCleanupJobMinimumAge();
+    defaultMinimumAge = kadaiEngine.getConfiguration().getTaskCleanupJobMinimumAge();
+    minimumAgeByDomain = kadaiEngine.getConfiguration().getTaskCleanupJobMinimumAgeByDomain();
     batchSize = kadaiEngine.getConfiguration().getTaskCleanupJobBatchSize();
     allCompletedSameParentBusiness =
         kadaiEngine.getConfiguration().isTaskCleanupJobAllCompletedSameParentBusiness();
@@ -68,12 +72,23 @@ public class TaskCleanupJob extends AbstractKadaiJob {
 
   @Override
   public void execute() {
-    Instant completedBefore = Instant.now().minus(minimumAge);
+    Instant cleanupRunTime = Instant.now();
+    Instant defaultCompletedBefore = cleanupRunTime.minus(defaultMinimumAge);
+    Map<String, Instant> completedBeforeByDomain =
+        calculateCompletedBeforeByDomain(cleanupRunTime);
     long jobStartedAt = System.nanoTime();
-    LOGGER.info("Running job to delete all tasks completed before ({})", completedBefore);
+    LOGGER.info(
+        "Running task cleanup with default minimum age {} and {} domain override(s).",
+        defaultMinimumAge,
+        minimumAgeByDomain.size());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Task cleanup completed-before cutoffs by domain: {}", completedBeforeByDomain);
+    }
     try {
       long selectionStartedAt = System.nanoTime();
-      List<String> tasksCompletedBefore = getTasksCompletedBeforeTransactionally(completedBefore);
+      List<String> tasksCompletedBefore =
+          getTaskIdsEligibleForCleanupTransactionally(
+              defaultCompletedBefore, completedBeforeByDomain);
       LOGGER.info(
           "Selected {} tasks for cleanup in {} ms.",
           tasksCompletedBefore.size(),
@@ -98,22 +113,53 @@ public class TaskCleanupJob extends AbstractKadaiJob {
     return TaskCleanupJob.class.getName();
   }
 
-  private List<String> getTasksCompletedBefore(Instant untilDate) {
-    return kadaiEngineImpl.executeInDatabaseConnection(
-        () ->
-            allCompletedSameParentBusiness
-                ? kadaiEngineImpl
-                    .getTaskMapper()
-                    .findTasksCompletedBeforeWithParentBusinessProcessConstraint(untilDate)
-                : kadaiEngineImpl.getTaskMapper().findTasksCompletedBefore(untilDate));
+  private Map<String, Instant> calculateCompletedBeforeByDomain(Instant cleanupRunTime) {
+    Map<String, Instant> completedBeforeByDomain = new LinkedHashMap<>();
+    minimumAgeByDomain.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            entry ->
+                completedBeforeByDomain.put(
+                    entry.getKey(), cleanupRunTime.minus(entry.getValue())));
+    return completedBeforeByDomain;
   }
 
-  private List<String> getTasksCompletedBeforeTransactionally(Instant untilDate) {
+  private List<String> getTaskIdsEligibleForCleanup(
+      Instant defaultCompletedBefore, Map<String, Instant> completedBeforeByDomain) {
+    return kadaiEngineImpl.executeInDatabaseConnection(
+        () ->
+            getTaskIdsEligibleForCleanup(
+                defaultCompletedBefore, completedBeforeByDomain, allCompletedSameParentBusiness));
+  }
+
+  private List<String> getTaskIdsEligibleForCleanup(
+      Instant defaultCompletedBefore,
+      Map<String, Instant> completedBeforeByDomain,
+      boolean requireAllCompletedSameParentBusiness) {
+    if (completedBeforeByDomain.isEmpty()) {
+      return requireAllCompletedSameParentBusiness
+          ? kadaiEngineImpl
+              .getTaskMapper()
+              .findTasksCompletedBeforeWithParentBusinessProcessConstraint(defaultCompletedBefore)
+          : kadaiEngineImpl.getTaskMapper().findTasksCompletedBefore(defaultCompletedBefore);
+    }
+    return requireAllCompletedSameParentBusiness
+        ? kadaiEngineImpl
+            .getTaskMapper()
+            .findTasksCompletedBeforeByDomainWithParentBusinessProcessConstraint(
+                defaultCompletedBefore, completedBeforeByDomain)
+        : kadaiEngineImpl
+            .getTaskMapper()
+            .findTasksCompletedBeforeByDomain(defaultCompletedBefore, completedBeforeByDomain);
+  }
+
+  private List<String> getTaskIdsEligibleForCleanupTransactionally(
+      Instant defaultCompletedBefore, Map<String, Instant> completedBeforeByDomain) {
     return KadaiTransactionProvider.executeInTransactionIfPossible(
         txProvider,
         () -> {
           renewLock();
-          return getTasksCompletedBefore(untilDate);
+          return getTaskIdsEligibleForCleanup(defaultCompletedBefore, completedBeforeByDomain);
         });
   }
 
@@ -179,8 +225,10 @@ public class TaskCleanupJob extends AbstractKadaiJob {
         + txProvider
         + ", scheduledJob="
         + scheduledJob
-        + ", minimumAge="
-        + minimumAge
+        + ", defaultMinimumAge="
+        + defaultMinimumAge
+        + ", minimumAgeByDomain="
+        + minimumAgeByDomain
         + ", batchSize="
         + batchSize
         + ", allCompletedSameParentBusiness="


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] Documentation: https://github.com/kadai-io/kadai-doc/pull/247
- [x] If extra release-notes are required, they’re listed indented below:
  * Added domain-specific retention periods for completed tasks via `kadai.jobs.cleanup.task.minimumAgeByDomain.<DOMAIN>`.
  * `kadai.jobs.cleanup.task.minimumAge` remains the default fallback for domains without an explicit override.
  * Parent-business-process cleanup respects each task’s domain-specific retention period when `allCompletedSameParentBusiness=true`.
  * Existing configurations without domain-specific overrides continue to behave unchanged.
