### PR TITLE
Closes #2166 - Prevent stale access id lookup responses in type ahead

### DIFF
--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -20,7 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { TypeAheadComponent } from './type-ahead.component';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
-import { delay, of } from 'rxjs';
+import { delay, of, Subject } from 'rxjs';
 import { provideStore, Store } from '@ngxs/store';
 import { EngineConfigurationState } from '../../store/engine-configuration-store/engine-configuration.state';
 import { engineConfigurationMock } from '../../store/mock-data/mock-store';
@@ -189,11 +189,16 @@ describe('TypeAheadComponent with AccessId input', () => {
   });
 
   it('should ignore stale/older search requests if a new input was provided (prevent race condition)', async () => {
+    vi.useFakeTimers();
+
+    const requestA$ = new Subject<any>();
+    const requestB$ = new Subject<any>();
+
     const searchSpy = vi
       .spyOn(accessIdService, 'searchForAccessId')
       .mockReset()
-      .mockReturnValueOnce(of([{ accessId: 'user-a', name: 'User A' }]).pipe(delay(50))) // simulation of a long request
-      .mockReturnValueOnce(of([{ accessId: 'user-b', name: 'User B' }]).pipe(delay(10))); // the second request was sent later but was processed first
+      .mockReturnValueOnce(requestA$.asObservable())
+      .mockReturnValueOnce(requestB$.asObservable());
 
     const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
 
@@ -201,31 +206,31 @@ describe('TypeAheadComponent with AccessId input', () => {
     inputEl.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-    await vi.waitFor(
-      () => {
-        expect(searchSpy).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 750 }
-    );
+    vi.advanceTimersByTime(component.debounceTime);
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy).toHaveBeenLastCalledWith('user-a');
 
     inputEl.value = 'user-b';
     inputEl.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-    await vi.waitFor(
-      () => {
-        expect(searchSpy).toHaveBeenCalledTimes(2);
-      },
-      { timeout: 750 }
-    );
+    vi.advanceTimersByTime(component.debounceTime);
+    expect(searchSpy).toHaveBeenCalledTimes(2);
+    expect(searchSpy).toHaveBeenLastCalledWith('user-b');
 
-    await vi.waitFor(
-      () => {
-        fixture.detectChanges();
-        expect(component.name()).toBe('User B');
-      },
-      { timeout: 750 }
-    );
+    requestB$.next([{ accessId: 'user-b', name: 'User B' }]);
+    requestB$.complete();
+    fixture.detectChanges();
+
+    expect(component.name()).toBe('User B');
+
+    requestA$.next([{ accessId: 'user-a', name: 'User A' }]);
+    requestA$.complete();
+    fixture.detectChanges();
+
+    expect(component.name()).toBe('User B');
+
+    vi.useRealTimers();
   });
 });
 

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -166,35 +166,45 @@ describe('TypeAheadComponent with AccessId input', () => {
     expect(setAccessIdSpy).not.toHaveBeenCalled();
   });
 
-it('should ignore stale/older search requests if a new input was provided (prevent race condition)', async () => {
-  const searchSpy = vi.spyOn(accessIdService, 'searchForAccessId')
-    .mockReset()
-    .mockReturnValueOnce(of([{ accessId: 'user-a', name: 'User A' }]).pipe(delay(50)))   // simulation of a long request
-    .mockReturnValueOnce(of([{ accessId: 'user-b', name: 'User B' }]).pipe(delay(10)));  // the second request was sent later but was processed first
+  it('should ignore stale/older search requests if a new input was provided (prevent race condition)', async () => {
+    const searchSpy = vi
+      .spyOn(accessIdService, 'searchForAccessId')
+      .mockReset()
+      .mockReturnValueOnce(of([{ accessId: 'user-a', name: 'User A' }]).pipe(delay(50))) // simulation of a long request
+      .mockReturnValueOnce(of([{ accessId: 'user-b', name: 'User B' }]).pipe(delay(10))); // the second request was sent later but was processed first
 
-  const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
 
-  inputEl.value = 'user-a';
-  inputEl.dispatchEvent(new Event('input'));
-  fixture.detectChanges();
-
-  await vi.waitFor(() => {
-    expect(searchSpy).toHaveBeenCalledTimes(1);
-  }, { timeout: 750 });
-
-  inputEl.value = 'user-b';
-  inputEl.dispatchEvent(new Event('input'));
-  fixture.detectChanges();
-
-  await vi.waitFor(() => {
-    expect(searchSpy).toHaveBeenCalledTimes(2);
-  }, { timeout: 750 });
-
-  await vi.waitFor(() => {
+    inputEl.value = 'user-a';
+    inputEl.dispatchEvent(new Event('input'));
     fixture.detectChanges();
-    expect(component.name()).toBe('User B');
-  }, { timeout: 750 });
-});
+
+    await vi.waitFor(
+      () => {
+        expect(searchSpy).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 750 }
+    );
+
+    inputEl.value = 'user-b';
+    inputEl.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    await vi.waitFor(
+      () => {
+        expect(searchSpy).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 750 }
+    );
+
+    await vi.waitFor(
+      () => {
+        fixture.detectChanges();
+        expect(component.name()).toBe('User B');
+      },
+      { timeout: 750 }
+    );
+  });
 });
 
 describe('TypeAheadComponent without debounceTime configured', () => {

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -20,7 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { TypeAheadComponent } from './type-ahead.component';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
-import { delay, of, Subject } from 'rxjs';
+import { delay, of } from 'rxjs';
 import { provideStore, Store } from '@ngxs/store';
 import { EngineConfigurationState } from '../../store/engine-configuration-store/engine-configuration.state';
 import { engineConfigurationMock } from '../../store/mock-data/mock-store';

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -165,6 +165,29 @@ describe('TypeAheadComponent with AccessId input', () => {
     expect(setAccessIdSpy).not.toHaveBeenCalled();
   });
 
+  it('should call handleEmptyAccessId and not search when accessId value is cleared or empty', async () => {
+    const handleEmptyAccessIdSpy = vi.spyOn(component, 'handleEmptyAccessId');
+    const searchSpy = vi.spyOn(accessIdService, 'searchForAccessId');
+
+    component.accessIdForm.get('accessId')!.setValue('user-g-1');
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(searchSpy).toHaveBeenCalledWith('user-g-1');
+    });
+
+    searchSpy.mockClear();
+    handleEmptyAccessIdSpy.mockClear();
+
+    component.accessIdForm.get('accessId')!.setValue('');
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(handleEmptyAccessIdSpy).toHaveBeenCalled();
+      expect(searchSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('should ignore stale/older search requests if a new input was provided (prevent race condition)', async () => {
     const searchSpy = vi
       .spyOn(accessIdService, 'searchForAccessId')

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -16,16 +16,17 @@
  *
  */
 
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { TypeAheadComponent } from './type-ahead.component';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
-import { of } from 'rxjs';
+import { delay, of, Subject } from 'rxjs';
 import { provideStore, Store } from '@ngxs/store';
 import { EngineConfigurationState } from '../../store/engine-configuration-store/engine-configuration.state';
 import { engineConfigurationMock } from '../../store/mock-data/mock-store';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccessId } from 'app/shared/models/access-id';
 
 const accessIdService: Partial<AccessIdsService> = {
   searchForAccessId: vi.fn().mockReturnValue(of([{ accessId: 'user-g-1', name: 'Gerda' }]))
@@ -164,6 +165,36 @@ describe('TypeAheadComponent with AccessId input', () => {
     const setAccessIdSpy = vi.spyOn(component, 'setAccessIdFromInput');
     expect(setAccessIdSpy).not.toHaveBeenCalled();
   });
+
+it('should ignore stale/older search requests if a new input was provided (prevent race condition)', async () => {
+  const searchSpy = vi.spyOn(accessIdService, 'searchForAccessId')
+    .mockReset()
+    .mockReturnValueOnce(of([{ accessId: 'user-a', name: 'User A' }]).pipe(delay(50)))   // simulation of a long request
+    .mockReturnValueOnce(of([{ accessId: 'user-b', name: 'User B' }]).pipe(delay(10)));  // the second request was sent later but was processed first
+
+  const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
+
+  inputEl.value = 'user-a';
+  inputEl.dispatchEvent(new Event('input'));
+  fixture.detectChanges();
+
+  await vi.waitFor(() => {
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+  }, { timeout: 750 });
+
+  inputEl.value = 'user-b';
+  inputEl.dispatchEvent(new Event('input'));
+  fixture.detectChanges();
+
+  await vi.waitFor(() => {
+    expect(searchSpy).toHaveBeenCalledTimes(2);
+  }, { timeout: 750 });
+
+  await vi.waitFor(() => {
+    fixture.detectChanges();
+    expect(component.name()).toBe('User B');
+  }, { timeout: 750 });
+});
 });
 
 describe('TypeAheadComponent without debounceTime configured', () => {

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.spec.ts
@@ -16,7 +16,7 @@
  *
  */
 
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { TypeAheadComponent } from './type-ahead.component';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
@@ -26,7 +26,6 @@ import { EngineConfigurationState } from '../../store/engine-configuration-store
 import { engineConfigurationMock } from '../../store/mock-data/mock-store';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AccessId } from 'app/shared/models/access-id';
 
 const accessIdService: Partial<AccessIdsService> = {
   searchForAccessId: vi.fn().mockReturnValue(of([{ accessId: 'user-g-1', name: 'Gerda' }]))

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -18,10 +18,10 @@
 
 import { Component, effect, inject, input, OnDestroy, OnInit, output, signal, untracked } from '@angular/core';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
-import { debounceTime, distinctUntilChanged, Observable, of, Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, Observable, of, Subject, timer } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AccessId } from '../../models/access-id';
-import { map, switchMap, take, takeUntil } from 'rxjs/operators';
+import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { WorkbasketSelectors } from '../../store/workbasket-store/workbasket.selectors';
 import { ButtonAction } from '../../../administration/models/button-action';
@@ -108,7 +108,6 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
 
     this.accessIdForm.controls['accessId'].valueChanges
       .pipe(
-        debounceTime(this.debounceTime),
         distinctUntilChanged(),
         switchMap((value) => {
           if (!value) {
@@ -116,7 +115,11 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
             return of(null);
           }
 
-          return this.accessIdService.searchForAccessId(value).pipe(map((accessIds) => ({ value, accessIds })));
+          return timer(this.debounceTime).pipe(
+            switchMap(() => this.accessIdService.searchForAccessId(value)),
+            map((accessIds) => ({ value, accessIds })),
+            catchError(() => of(null))
+          );
         }),
         takeUntil(this.destroy$)
       )

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -108,21 +108,19 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
 
     this.accessIdForm.controls['accessId'].valueChanges
       .pipe(
-        debounceTime(this.debounceTime), 
-        distinctUntilChanged(), 
-        switchMap(
-          (value) => {
-            if (!value) {
-              this.handleEmptyAccessId();
-              return of(null);
-            }
-
-            return this.accessIdService.searchForAccessId(value).pipe(
-              map((accessIds) => ({value, accessIds})),
-              catchError(() => of(null))
-            )
+        debounceTime(this.debounceTime),
+        distinctUntilChanged(),
+        switchMap((value) => {
+          if (!value) {
+            this.handleEmptyAccessId();
+            return of(null);
           }
-        ), 
+
+          return this.accessIdService.searchForAccessId(value).pipe(
+            map((accessIds) => ({ value, accessIds })),
+            catchError(() => of(null))
+          );
+        }),
         takeUntil(this.destroy$)
       )
       .subscribe((result) => {
@@ -130,7 +128,7 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
         this.processAccessIdResult(result.value, result?.accessIds);
       });
   }
-  
+
   handleEmptyAccessId() {
     this.name.set('');
     this.isFormValid.emit(!this.isRequired());

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -116,10 +116,7 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
             return of(null);
           }
 
-          return this.accessIdService.searchForAccessId(value).pipe(
-            map((accessIds) => ({ value, accessIds })),
-            catchError(() => of(null))
-          );
+          return this.accessIdService.searchForAccessId(value).pipe(map((accessIds) => ({ value, accessIds })));
         }),
         takeUntil(this.destroy$)
       )

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -21,7 +21,7 @@ import { AccessIdsService } from '../../services/access-ids/access-ids.service';
 import { debounceTime, distinctUntilChanged, Observable, of, Subject } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AccessId } from '../../models/access-id';
-import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
+import { map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { WorkbasketSelectors } from '../../store/workbasket-store/workbasket.selectors';
 import { ButtonAction } from '../../../administration/models/button-action';

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -18,10 +18,10 @@
 
 import { Component, effect, inject, input, OnDestroy, OnInit, output, signal, untracked } from '@angular/core';
 import { AccessIdsService } from '../../services/access-ids/access-ids.service';
-import { debounceTime, distinctUntilChanged, Observable, Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, Observable, of, Subject } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AccessId } from '../../models/access-id';
-import { map, take, takeUntil } from 'rxjs/operators';
+import { catchError, map, switchMap, take, takeUntil } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 import { WorkbasketSelectors } from '../../store/workbasket-store/workbasket.selectors';
 import { ButtonAction } from '../../../administration/models/button-action';
@@ -107,17 +107,30 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
       });
 
     this.accessIdForm.controls['accessId'].valueChanges
-      .pipe(debounceTime(this.debounceTime), distinctUntilChanged(), takeUntil(this.destroy$))
-      .subscribe(() => {
-        const value = this.accessIdForm.controls['accessId'].value;
-        if (value === '') {
-          this.handleEmptyAccessId();
-          return;
-        }
-        this.searchForAccessId(value!);
+      .pipe(
+        debounceTime(this.debounceTime), 
+        distinctUntilChanged(), 
+        switchMap(
+          (value) => {
+            if (!value) {
+              this.handleEmptyAccessId();
+              return of(null);
+            }
+
+            return this.accessIdService.searchForAccessId(value).pipe(
+              map((accessIds) => ({value, accessIds})),
+              catchError(() => of(null))
+            )
+          }
+        ), 
+        takeUntil(this.destroy$)
+      )
+      .subscribe((result) => {
+        if (!result) return;
+        this.processAccessIdResult(result.value, result?.accessIds);
       });
   }
-
+  
   handleEmptyAccessId() {
     this.name.set('');
     this.isFormValid.emit(!this.isRequired());
@@ -133,21 +146,23 @@ export class TypeAheadComponent implements OnInit, OnDestroy {
     this.accessIdService
       .searchForAccessId(value)
       .pipe(take(1))
-      .subscribe((accessIds) => {
-        this.filteredAccessIds.set(accessIds);
-        const accessId = accessIds.find((accessId) => accessId.accessId?.toLowerCase() === value.toLowerCase());
+      .subscribe((accessIds) => this.processAccessIdResult(value, accessIds));
+  }
 
-        if (typeof accessId !== 'undefined') {
-          this.name.set(accessId?.name ?? '');
-          this.isFormValid.emit(true);
-          this.accessIdEventEmitter.emit(accessId);
-        } else if (this.displayError()) {
-          this.isFormValid.emit(false);
-          this.accessIdEventEmitter.emit(this.emptyAccessId);
-          this.accessIdForm.controls['accessId'].setErrors({ incorrect: true });
-          this.accessIdForm.controls['accessId'].markAsTouched();
-        }
-      });
+  private processAccessIdResult(value: string, accessIds: AccessId[]) {
+    this.filteredAccessIds.set(accessIds);
+    const accessId = accessIds.find((item) => item.accessId?.toLowerCase() === value.toLowerCase());
+
+    if (typeof accessId !== 'undefined') {
+      this.name.set(accessId?.name ?? '');
+      this.isFormValid.emit(true);
+      this.accessIdEventEmitter.emit(accessId);
+    } else if (this.displayError()) {
+      this.isFormValid.emit(false);
+      this.accessIdEventEmitter.emit(this.emptyAccessId);
+      this.accessIdForm.controls['accessId'].setErrors({ incorrect: true });
+      this.accessIdForm.controls['accessId'].markAsTouched();
+    }
   }
 
   setAccessIdFromInput() {


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
    - Fixed a race condition in the Access ID lookup. Outdated server responses no longer overwrite the latest input value.