### PR TITLE
Closes #2179 - Eliminate n+1 queries in user retrieval

### DIFF
--- a/lib/kadai-core-test/src/test/java/acceptance/user/UserServiceAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/user/UserServiceAccTest.java
@@ -41,6 +41,7 @@ import io.kadai.user.api.UserService;
 import io.kadai.user.api.exceptions.UserAlreadyExistException;
 import io.kadai.user.api.exceptions.UserNotFoundException;
 import io.kadai.user.api.models.User;
+import io.kadai.user.api.models.UserSummary;
 import io.kadai.workbasket.api.WorkbasketPermission;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.models.Workbasket;
@@ -180,6 +181,92 @@ class UserServiceAccTest {
 
     @WithAccessId(user = "user-1-1")
     @Test
+    void should_EnrichUsersInBulk_When_QueryingUsers() throws Exception {
+      User userA =
+          randomTestUser()
+              .groups(Set.of("query-group-a"))
+              .permissions(Set.of("query-permission-a"))
+              .buildAndStore(userService, "businessadmin");
+      User userB =
+          randomTestUser()
+              .groups(Set.of("query-group-b"))
+              .permissions(Set.of("query-permission-b"))
+              .buildAndStore(userService, "businessadmin");
+
+      List<UserSummary> queriedUsers =
+          userService.createUserQuery().idIn(userA.getId(), userB.getId()).list();
+
+      assertThat(queriedUsers).hasSize(2);
+      UserSummary queriedUserA =
+          queriedUsers.stream()
+              .filter(user -> userA.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+      UserSummary queriedUserB =
+          queriedUsers.stream()
+              .filter(user -> userB.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(queriedUserA.getGroups()).containsExactly("query-group-a");
+      assertThat(queriedUserA.getPermissions()).containsExactly("query-permission-a");
+      assertThat(queriedUserB.getGroups()).containsExactly("query-group-b");
+      assertThat(queriedUserB.getPermissions()).containsExactly("query-permission-b");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_EnrichUsersInBulk_When_QueryingUsersWithPagination() throws Exception {
+      User userA =
+          randomTestUser()
+              .groups(Set.of("pagination-group-a"))
+              .permissions(Set.of("pagination-permission-a"))
+              .buildAndStore(userService, "businessadmin");
+      User userB =
+          randomTestUser()
+              .groups(Set.of("pagination-group-b"))
+              .permissions(Set.of("pagination-permission-b"))
+              .buildAndStore(userService, "businessadmin");
+
+      List<UserSummary> queriedUsers =
+          userService.createUserQuery().idIn(userA.getId(), userB.getId()).list(0, 2);
+
+      assertThat(queriedUsers).hasSize(2);
+      UserSummary queriedUserA =
+          queriedUsers.stream()
+              .filter(user -> userA.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+      UserSummary queriedUserB =
+          queriedUsers.stream()
+              .filter(user -> userB.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(queriedUserA.getGroups()).containsExactly("pagination-group-a");
+      assertThat(queriedUserA.getPermissions()).containsExactly("pagination-permission-a");
+      assertThat(queriedUserB.getGroups()).containsExactly("pagination-group-b");
+      assertThat(queriedUserB.getPermissions()).containsExactly("pagination-permission-b");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_EnrichUserInBulk_When_UsingSingleUserQuery() throws Exception {
+      User expected =
+          randomTestUser()
+              .groups(Set.of("single-query-group"))
+              .permissions(Set.of("single-query-permission"))
+              .buildAndStore(userService, "businessadmin");
+
+      UserSummary actual = userService.createUserQuery().idIn(expected.getId()).single();
+
+      assertThat(actual.getId()).isEqualTo(expected.getId());
+      assertThat(actual.getGroups()).containsExactly("single-query-group");
+      assertThat(actual.getPermissions()).containsExactly("single-query-permission");
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
     void should_DetermineDomains_When_WorkbasketPermissionsExistForUsers() throws Exception {
       Workbasket workbasketDomainA =
           defaultTestWorkbasket().buildAndStore(workbasketService, "businessadmin");
@@ -267,6 +354,39 @@ class UserServiceAccTest {
               4,
               new Condition<>(
                   domains -> Set.of(workbasketDomainB.getDomain()).equals(domains), "DOMAIN_B"));
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_AggregatePermissionsPerUserAndWorkbasket_When_GettingUsers() throws Exception {
+      Workbasket workbasket =
+          defaultTestWorkbasket().buildAndStore(workbasketService, "businessadmin");
+      createAccessItem("bulk-read", workbasket, WorkbasketPermission.READ);
+      createAccessItem("bulk-open", workbasket, WorkbasketPermission.OPEN);
+
+      User completeUser =
+          randomTestUser()
+              .groups(Set.of("bulk-read", "bulk-open"))
+              .buildAndStore(userService, "businessadmin");
+      User incompleteUser =
+          randomTestUser().groups(Set.of("bulk-read")).buildAndStore(userService, "businessadmin");
+
+      List<User> users =
+          userService.getUsers(Set.of(completeUser.getId(), incompleteUser.getId()));
+
+      User returnedCompleteUser =
+          users.stream()
+              .filter(user -> completeUser.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+      User returnedIncompleteUser =
+          users.stream()
+              .filter(user -> incompleteUser.getId().equals(user.getId()))
+              .findFirst()
+              .orElseThrow();
+
+      assertThat(returnedCompleteUser.getDomains()).containsExactly(workbasket.getDomain());
+      assertThat(returnedIncompleteUser.getDomains()).isEmpty();
     }
 
     @WithAccessId(user = "user-1-1")

--- a/lib/kadai-core-test/src/test/java/acceptance/user/UserServiceAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/user/UserServiceAccTest.java
@@ -182,6 +182,14 @@ class UserServiceAccTest {
     @WithAccessId(user = "user-1-1")
     @Test
     void should_EnrichUsersInBulk_When_QueryingUsers() throws Exception {
+      Workbasket workbasket =
+          defaultTestWorkbasket().buildAndStore(workbasketService, "businessadmin");
+      createAccessItem(
+          "query-group-a",
+          workbasket,
+          WorkbasketPermission.READ,
+          WorkbasketPermission.OPEN);
+
       User userA =
           randomTestUser()
               .groups(Set.of("query-group-a"))
@@ -210,8 +218,10 @@ class UserServiceAccTest {
 
       assertThat(queriedUserA.getGroups()).containsExactly("query-group-a");
       assertThat(queriedUserA.getPermissions()).containsExactly("query-permission-a");
+      assertThat(queriedUserA.getDomains()).containsExactly(workbasket.getDomain());
       assertThat(queriedUserB.getGroups()).containsExactly("query-group-b");
       assertThat(queriedUserB.getPermissions()).containsExactly("query-permission-b");
+      assertThat(queriedUserB.getDomains()).isEmpty();
     }
 
     @WithAccessId(user = "user-1-1")
@@ -387,6 +397,35 @@ class UserServiceAccTest {
 
       assertThat(returnedCompleteUser.getDomains()).containsExactly(workbasket.getDomain());
       assertThat(returnedIncompleteUser.getDomains()).isEmpty();
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_NotAggregatePermissionsAcrossWorkbaskets_When_GettingUsers() throws Exception {
+      Workbasket readWorkbasket =
+          defaultTestWorkbasket()
+              .domain("DOMAIN_A")
+              .buildAndStore(workbasketService, "businessadmin");
+      Workbasket openWorkbasket =
+          defaultTestWorkbasket()
+              .domain("DOMAIN_A")
+              .buildAndStore(workbasketService, "businessadmin");
+
+      createAccessItem(
+          "bulk-read-other-workbasket", readWorkbasket, WorkbasketPermission.READ);
+      createAccessItem(
+          "bulk-open-other-workbasket", openWorkbasket, WorkbasketPermission.OPEN);
+
+      User user =
+          randomTestUser()
+              .groups(
+                  Set.of("bulk-read-other-workbasket", "bulk-open-other-workbasket"))
+              .buildAndStore(userService, "businessadmin");
+
+      User returnedUser =
+          userService.getUsers(Set.of(user.getId())).stream().findFirst().orElseThrow();
+
+      assertThat(returnedUser.getDomains()).isEmpty();
     }
 
     @WithAccessId(user = "user-1-1")

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapper.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapper.java
@@ -19,7 +19,9 @@
 package io.kadai.user.internal;
 
 import io.kadai.user.api.models.User;
+import io.kadai.user.internal.models.UserAttributeRow;
 import io.kadai.user.internal.models.UserImpl;
+import io.kadai.workbasket.api.WorkbasketPermission;
 import java.util.List;
 import java.util.Set;
 import org.apache.ibatis.annotations.DeleteProvider;
@@ -53,11 +55,6 @@ public interface UserMapper {
   UserImpl findById(String id);
 
   @Result(property = "id", column = "USER_ID")
-  @Result(property = "groups", column = "USER_ID", many = @Many(select = "findGroupsById"))
-  @Result(
-      property = "permissions",
-      column = "USER_ID",
-      many = @Many(select = "findPermissionsById"))
   @Result(property = "firstName", column = "FIRST_NAME")
   @Result(property = "lastName", column = "LAST_NAME")
   @Result(property = "fullName", column = "FULL_NAME")
@@ -78,6 +75,23 @@ public interface UserMapper {
 
   @SelectProvider(type = UserMapperSqlProvider.class, method = "findPermissionsById")
   Set<String> findPermissionsById(String id);
+
+  @SelectProvider(type = UserMapperSqlProvider.class, method = "findGroupsByIds")
+  @Result(property = "userId", column = "USER_ID")
+  @Result(property = "attributeValue", column = "ATTRIBUTE_VALUE")
+  List<UserAttributeRow> findGroupsByIds(@Param("ids") Set<String> ids);
+
+  @SelectProvider(type = UserMapperSqlProvider.class, method = "findPermissionsByIds")
+  @Result(property = "userId", column = "USER_ID")
+  @Result(property = "attributeValue", column = "ATTRIBUTE_VALUE")
+  List<UserAttributeRow> findPermissionsByIds(@Param("ids") Set<String> ids);
+
+  @SelectProvider(type = UserMapperSqlProvider.class, method = "findDomainsByIds")
+  @Result(property = "userId", column = "USER_ID")
+  @Result(property = "attributeValue", column = "ATTRIBUTE_VALUE")
+  List<UserAttributeRow> findDomainsByIds(
+      @Param("ids") Set<String> ids,
+      @Param("permissions") List<WorkbasketPermission> permissions);
 
   @InsertProvider(type = UserMapperSqlProvider.class, method = "insert")
   void insert(User user);

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapperSqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserMapperSqlProvider.java
@@ -31,6 +31,70 @@ public class UserMapperSqlProvider {
   private static final String USER_INFO_VALUES =
       "#{id}, #{firstName}, #{lastName}, #{fullName}, #{longName}, #{email}, #{phone}, "
           + "#{mobilePhone}, #{orgLevel4}, #{orgLevel3}, #{orgLevel2}, #{orgLevel1}, #{data} ";
+  private static final String IDS_FOREACH =
+      "<foreach item='id' collection='ids' separator=','>#{id}</foreach>";
+  private static final String DB2_PERMISSION_AGGREGATES =
+      "MAX(a.PERM_READ) AS MAX_READ, "
+          + "MAX(a.PERM_READTASKS) AS MAX_READTASKS, "
+          + "MAX(a.PERM_EDITTASKS) AS MAX_EDITTASKS, "
+          + "MAX(a.PERM_OPEN) AS MAX_OPEN, "
+          + "MAX(a.PERM_APPEND) AS MAX_APPEND, "
+          + "MAX(a.PERM_TRANSFER) AS MAX_TRANSFER, "
+          + "MAX(a.PERM_DISTRIBUTE) AS MAX_DISTRIBUTE, "
+          + "MAX(a.PERM_CUSTOM_1) AS MAX_CUSTOM_1, "
+          + "MAX(a.PERM_CUSTOM_2) AS MAX_CUSTOM_2, "
+          + "MAX(a.PERM_CUSTOM_3) AS MAX_CUSTOM_3, "
+          + "MAX(a.PERM_CUSTOM_4) AS MAX_CUSTOM_4, "
+          + "MAX(a.PERM_CUSTOM_5) AS MAX_CUSTOM_5, "
+          + "MAX(a.PERM_CUSTOM_6) AS MAX_CUSTOM_6, "
+          + "MAX(a.PERM_CUSTOM_7) AS MAX_CUSTOM_7, "
+          + "MAX(a.PERM_CUSTOM_8) AS MAX_CUSTOM_8, "
+          + "MAX(a.PERM_CUSTOM_9) AS MAX_CUSTOM_9, "
+          + "MAX(a.PERM_CUSTOM_10) AS MAX_CUSTOM_10, "
+          + "MAX(a.PERM_CUSTOM_11) AS MAX_CUSTOM_11, "
+          + "MAX(a.PERM_CUSTOM_12) AS MAX_CUSTOM_12 ";
+  private static final String BOOLEAN_PERMISSION_AGGREGATES =
+      "MAX(a.PERM_READ::int) AS MAX_READ, "
+          + "MAX(a.PERM_READTASKS::int) AS MAX_READTASKS, "
+          + "MAX(a.PERM_EDITTASKS::int) AS MAX_EDITTASKS, "
+          + "MAX(a.PERM_OPEN::int) AS MAX_OPEN, "
+          + "MAX(a.PERM_APPEND::int) AS MAX_APPEND, "
+          + "MAX(a.PERM_TRANSFER::int) AS MAX_TRANSFER, "
+          + "MAX(a.PERM_DISTRIBUTE::int) AS MAX_DISTRIBUTE, "
+          + "MAX(a.PERM_CUSTOM_1::int) AS MAX_CUSTOM_1, "
+          + "MAX(a.PERM_CUSTOM_2::int) AS MAX_CUSTOM_2, "
+          + "MAX(a.PERM_CUSTOM_3::int) AS MAX_CUSTOM_3, "
+          + "MAX(a.PERM_CUSTOM_4::int) AS MAX_CUSTOM_4, "
+          + "MAX(a.PERM_CUSTOM_5::int) AS MAX_CUSTOM_5, "
+          + "MAX(a.PERM_CUSTOM_6::int) AS MAX_CUSTOM_6, "
+          + "MAX(a.PERM_CUSTOM_7::int) AS MAX_CUSTOM_7, "
+          + "MAX(a.PERM_CUSTOM_8::int) AS MAX_CUSTOM_8, "
+          + "MAX(a.PERM_CUSTOM_9::int) AS MAX_CUSTOM_9, "
+          + "MAX(a.PERM_CUSTOM_10::int) AS MAX_CUSTOM_10, "
+          + "MAX(a.PERM_CUSTOM_11::int) AS MAX_CUSTOM_11, "
+          + "MAX(a.PERM_CUSTOM_12::int) AS MAX_CUSTOM_12 ";
+  private static final String PERMISSION_ALIAS =
+      "<choose>"
+          + "<when test=\"permission.name() == 'READ'\">awb.MAX_READ</when>"
+          + "<when test=\"permission.name() == 'READTASKS'\">awb.MAX_READTASKS</when>"
+          + "<when test=\"permission.name() == 'EDITTASKS'\">awb.MAX_EDITTASKS</when>"
+          + "<when test=\"permission.name() == 'OPEN'\">awb.MAX_OPEN</when>"
+          + "<when test=\"permission.name() == 'APPEND'\">awb.MAX_APPEND</when>"
+          + "<when test=\"permission.name() == 'TRANSFER'\">awb.MAX_TRANSFER</when>"
+          + "<when test=\"permission.name() == 'DISTRIBUTE'\">awb.MAX_DISTRIBUTE</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_1'\">awb.MAX_CUSTOM_1</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_2'\">awb.MAX_CUSTOM_2</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_3'\">awb.MAX_CUSTOM_3</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_4'\">awb.MAX_CUSTOM_4</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_5'\">awb.MAX_CUSTOM_5</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_6'\">awb.MAX_CUSTOM_6</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_7'\">awb.MAX_CUSTOM_7</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_8'\">awb.MAX_CUSTOM_8</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_9'\">awb.MAX_CUSTOM_9</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_10'\">awb.MAX_CUSTOM_10</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_11'\">awb.MAX_CUSTOM_11</when>"
+          + "<when test=\"permission.name() == 'CUSTOM_12'\">awb.MAX_CUSTOM_12</when>"
+          + "</choose>";
 
   private UserMapperSqlProvider() {}
 
@@ -64,6 +128,63 @@ public class UserMapperSqlProvider {
   public static String findPermissionsById() {
     return OPENING_SCRIPT_TAG
         + "SELECT PERMISSION_ID FROM PERMISSION_INFO WHERE USER_ID = #{id} "
+        + DB2_WITH_UR
+        + CLOSING_SCRIPT_TAG;
+  }
+
+  public static String findGroupsByIds() {
+    return OPENING_SCRIPT_TAG
+        + "SELECT USER_ID, GROUP_ID AS ATTRIBUTE_VALUE "
+        + "FROM GROUP_INFO WHERE USER_ID IN ("
+        + IDS_FOREACH
+        + ") "
+        + DB2_WITH_UR
+        + CLOSING_SCRIPT_TAG;
+  }
+
+  public static String findPermissionsByIds() {
+    return OPENING_SCRIPT_TAG
+        + "SELECT USER_ID, PERMISSION_ID AS ATTRIBUTE_VALUE "
+        + "FROM PERMISSION_INFO WHERE USER_ID IN ("
+        + IDS_FOREACH
+        + ") "
+        + DB2_WITH_UR
+        + CLOSING_SCRIPT_TAG;
+  }
+
+  public static String findDomainsByIds() {
+    return OPENING_SCRIPT_TAG
+        + "WITH REQUESTED_USERS AS ( "
+        + "SELECT USER_ID FROM USER_INFO WHERE USER_ID IN ("
+        + IDS_FOREACH
+        + ") "
+        + "), USER_ACCESS AS ( "
+        + "SELECT USER_ID, LOWER(USER_ID) AS ACCESS_ID FROM REQUESTED_USERS "
+        + "UNION ALL "
+        + "SELECT ru.USER_ID, LOWER(g.GROUP_ID) AS ACCESS_ID "
+        + "FROM REQUESTED_USERS ru JOIN GROUP_INFO g ON g.USER_ID = ru.USER_ID "
+        + "UNION ALL "
+        + "SELECT ru.USER_ID, LOWER(p.PERMISSION_ID) AS ACCESS_ID "
+        + "FROM REQUESTED_USERS ru JOIN PERMISSION_INFO p ON p.USER_ID = ru.USER_ID "
+        + "), ACCESS_BY_WORKBASKET AS ( "
+        + "SELECT ua.USER_ID, a.WORKBASKET_ID, "
+        + "<choose>"
+        + "<when test=\"_databaseId == 'db2'\">"
+        + DB2_PERMISSION_AGGREGATES
+        + "</when>"
+        + "<otherwise>"
+        + BOOLEAN_PERMISSION_AGGREGATES
+        + "</otherwise>"
+        + "</choose>"
+        + "FROM USER_ACCESS ua JOIN WORKBASKET_ACCESS_LIST a "
+        + "ON a.ACCESS_ID = ua.ACCESS_ID "
+        + "GROUP BY ua.USER_ID, a.WORKBASKET_ID "
+        + ") SELECT DISTINCT awb.USER_ID, w.DOMAIN AS ATTRIBUTE_VALUE "
+        + "FROM ACCESS_BY_WORKBASKET awb JOIN WORKBASKET w ON w.ID = awb.WORKBASKET_ID "
+        + "WHERE awb.MAX_READ = 1 "
+        + "AND <foreach item='permission' collection='permissions' separator=' AND '>"
+        + PERMISSION_ALIAS
+        + " = 1</foreach> "
         + DB2_WITH_UR
         + CLOSING_SCRIPT_TAG;
   }

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserQueryImpl.java
@@ -120,14 +120,12 @@ public class UserQueryImpl implements UserQuery {
   public List<UserSummary> list() {
     UserServiceImpl userService = (UserServiceImpl) kadaiEngine.getEngine().getUserService();
     return kadaiEngine.executeInDatabaseConnection(
-        () ->
-            kadaiEngine.getSqlSession().<UserImpl>selectList(LINK_TO_USER_MAPPER, this).stream()
-                .map(
-                    user -> {
-                      user.setDomains(userService.determineDomains(user));
-                      return (UserSummary) user;
-                    })
-                .toList());
+        () -> {
+          List<UserImpl> users =
+              kadaiEngine.getSqlSession().selectList(LINK_TO_USER_MAPPER, this);
+          userService.enrichUsers(users);
+          return users.stream().map(UserSummary.class::cast).toList();
+        });
   }
 
   @Override
@@ -136,16 +134,10 @@ public class UserQueryImpl implements UserQuery {
       UserServiceImpl userService = (UserServiceImpl) kadaiEngine.getEngine().getUserService();
       kadaiEngine.openConnection();
       RowBounds rowBounds = new RowBounds(offset, limit);
-      return kadaiEngine
-          .getSqlSession()
-          .<UserImpl>selectList(LINK_TO_USER_MAPPER, this, rowBounds)
-          .stream()
-          .map(
-              user -> {
-                user.setDomains(userService.determineDomains(user));
-                return (UserSummary) user;
-              })
-          .toList();
+      List<UserImpl> users =
+          kadaiEngine.getSqlSession().selectList(LINK_TO_USER_MAPPER, this, rowBounds);
+      userService.enrichUsers(users);
+      return users.stream().map(UserSummary.class::cast).toList();
     } catch (PersistenceException e) {
       if (e.getMessage().contains("ERRORCODE=-4470")) {
         KadaiRuntimeException ex =
@@ -179,7 +171,9 @@ public class UserQueryImpl implements UserQuery {
       UserServiceImpl userService = (UserServiceImpl) kadaiEngine.getEngine().getUserService();
       kadaiEngine.openConnection();
       UserImpl user = kadaiEngine.getSqlSession().selectOne(LINK_TO_USER_MAPPER, this);
-      user.setDomains(userService.determineDomains(user));
+      if (user != null) {
+        userService.enrichUsers(List.of(user));
+      }
       return user;
     } finally {
       kadaiEngine.returnConnection();

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserQueryMapper.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserQueryMapper.java
@@ -20,7 +20,6 @@ package io.kadai.user.internal;
 
 import io.kadai.user.internal.models.UserImpl;
 import java.util.List;
-import org.apache.ibatis.annotations.Many;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.SelectProvider;
 
@@ -31,14 +30,6 @@ public interface UserQueryMapper {
 
   @SelectProvider(type = UserQuerySqlProvider.class, method = "queryUsers")
   @Result(property = "id", column = "USER_ID")
-  @Result(
-      property = "groups",
-      column = "USER_ID",
-      many = @Many(select = "io.kadai.user.internal.UserMapper.findGroupsById"))
-  @Result(
-      property = "permissions",
-      column = "USER_ID",
-      many = @Many(select = "io.kadai.user.internal.UserMapper.findPermissionsById"))
   @Result(property = "firstName", column = "FIRST_NAME")
   @Result(property = "lastName", column = "LAST_NAME")
   @Result(property = "fullName", column = "FULL_NAME")

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
@@ -49,6 +49,9 @@ import org.slf4j.LoggerFactory;
 
 public class UserServiceImpl implements UserService {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserServiceImpl.class);
+  // Keep enrichment statements below database bind-parameter limits.
+  // Broader dynamic-SQL batching is tracked in #1206.
+  private static final int USER_ENRICHMENT_BATCH_SIZE = 10_000;
   private final InternalKadaiEngine internalKadaiEngine;
   private final UserMapper userMapper;
   private final WorkbasketService workbasketService;
@@ -195,39 +198,49 @@ public class UserServiceImpl implements UserService {
       return;
     }
 
-    Set<String> userIds = users.stream().map(UserImpl::getId).collect(Collectors.toSet());
+    List<String> userIds = users.stream().map(UserImpl::getId).distinct().toList();
 
-    Map<String, Set<String>> groupsByUserId =
-        toUserAttributeMap(userMapper.findGroupsByIds(userIds));
-    Map<String, Set<String>> permissionsByUserId =
-        toUserAttributeMap(userMapper.findPermissionsByIds(userIds));
+    Map<String, Set<String>> groupsByUserId = new HashMap<>();
+    Map<String, Set<String>> permissionsByUserId = new HashMap<>();
+    Map<String, Set<String>> domainsByUserId = new HashMap<>();
 
-    Map<String, Set<String>> domainsByUserId;
-    if (minimalWorkbasketPermissions == null || minimalWorkbasketPermissions.isEmpty()) {
-      domainsByUserId = Collections.emptyMap();
-    } else {
-      domainsByUserId =
-          toUserAttributeMap(userMapper.findDomainsByIds(userIds, minimalWorkbasketPermissions));
+    boolean resolveDomains =
+        minimalWorkbasketPermissions != null && !minimalWorkbasketPermissions.isEmpty();
+
+    for (int fromIndex = 0;
+        fromIndex < userIds.size();
+        fromIndex += USER_ENRICHMENT_BATCH_SIZE) {
+      int toIndex = Math.min(fromIndex + USER_ENRICHMENT_BATCH_SIZE, userIds.size());
+      Set<String> batchUserIds = new HashSet<>(userIds.subList(fromIndex, toIndex));
+
+      addUserAttributes(groupsByUserId, userMapper.findGroupsByIds(batchUserIds));
+      addUserAttributes(permissionsByUserId, userMapper.findPermissionsByIds(batchUserIds));
+
+      if (resolveDomains) {
+        addUserAttributes(
+            domainsByUserId,
+            userMapper.findDomainsByIds(batchUserIds, minimalWorkbasketPermissions));
+      }
     }
 
     for (UserImpl user : users) {
-      user.setGroups(groupsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
+      user.setGroups(
+          new HashSet<>(groupsByUserId.getOrDefault(user.getId(), Collections.emptySet())));
       user.setPermissions(
-          permissionsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
-      user.setDomains(domainsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
+          new HashSet<>(
+              permissionsByUserId.getOrDefault(user.getId(), Collections.emptySet())));
+      user.setDomains(
+          new HashSet<>(domainsByUserId.getOrDefault(user.getId(), Collections.emptySet())));
     }
   }
 
-  private static Map<String, Set<String>> toUserAttributeMap(List<UserAttributeRow> rows) {
-    Map<String, Set<String>> attributesByUserId = new HashMap<>();
-
+  private static void addUserAttributes(
+      Map<String, Set<String>> attributesByUserId, List<UserAttributeRow> rows) {
     for (UserAttributeRow row : rows) {
       attributesByUserId
           .computeIfAbsent(row.getUserId(), ignored -> new HashSet<>())
           .add(row.getAttributeValue());
     }
-
-    return attributesByUserId;
   }
 
   Set<String> determineDomains(User user) {

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/UserServiceImpl.java
@@ -31,13 +31,16 @@ import io.kadai.user.api.UserService;
 import io.kadai.user.api.exceptions.UserAlreadyExistException;
 import io.kadai.user.api.exceptions.UserNotFoundException;
 import io.kadai.user.api.models.User;
+import io.kadai.user.internal.models.UserAttributeRow;
 import io.kadai.user.internal.models.UserImpl;
 import io.kadai.workbasket.api.WorkbasketPermission;
 import io.kadai.workbasket.api.WorkbasketQueryColumnName;
 import io.kadai.workbasket.api.WorkbasketService;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.ibatis.exceptions.PersistenceException;
@@ -94,9 +97,12 @@ public class UserServiceImpl implements UserService {
         userIds.stream().map(String::toLowerCase).collect(Collectors.toSet());
 
     List<UserImpl> users =
-        internalKadaiEngine.executeInDatabaseConnection(() -> userMapper.findByIds(finalUserIds));
-
-    users.forEach(user -> user.setDomains(determineDomains(user)));
+        internalKadaiEngine.executeInDatabaseConnection(
+            () -> {
+              List<UserImpl> foundUsers = userMapper.findByIds(finalUserIds);
+              enrichUsers(foundUsers);
+              return foundUsers;
+            });
 
     return users.stream().map(User.class::cast).toList();
   }
@@ -182,6 +188,46 @@ public class UserServiceImpl implements UserService {
           userMapper.deleteAllGroups();
           userMapper.deleteAllPermissions();
         });
+  }
+
+  void enrichUsers(List<UserImpl> users) {
+    if (users == null || users.isEmpty()) {
+      return;
+    }
+
+    Set<String> userIds = users.stream().map(UserImpl::getId).collect(Collectors.toSet());
+
+    Map<String, Set<String>> groupsByUserId =
+        toUserAttributeMap(userMapper.findGroupsByIds(userIds));
+    Map<String, Set<String>> permissionsByUserId =
+        toUserAttributeMap(userMapper.findPermissionsByIds(userIds));
+
+    Map<String, Set<String>> domainsByUserId;
+    if (minimalWorkbasketPermissions == null || minimalWorkbasketPermissions.isEmpty()) {
+      domainsByUserId = Collections.emptyMap();
+    } else {
+      domainsByUserId =
+          toUserAttributeMap(userMapper.findDomainsByIds(userIds, minimalWorkbasketPermissions));
+    }
+
+    for (UserImpl user : users) {
+      user.setGroups(groupsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
+      user.setPermissions(
+          permissionsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
+      user.setDomains(domainsByUserId.getOrDefault(user.getId(), Collections.emptySet()));
+    }
+  }
+
+  private static Map<String, Set<String>> toUserAttributeMap(List<UserAttributeRow> rows) {
+    Map<String, Set<String>> attributesByUserId = new HashMap<>();
+
+    for (UserAttributeRow row : rows) {
+      attributesByUserId
+          .computeIfAbsent(row.getUserId(), ignored -> new HashSet<>())
+          .add(row.getAttributeValue());
+    }
+
+    return attributesByUserId;
   }
 
   Set<String> determineDomains(User user) {

--- a/lib/kadai-core/src/main/java/io/kadai/user/internal/models/UserAttributeRow.java
+++ b/lib/kadai-core/src/main/java/io/kadai/user/internal/models/UserAttributeRow.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.user.internal.models;
+
+public class UserAttributeRow {
+
+  private String userId;
+  private String attributeValue;
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public String getAttributeValue() {
+    return attributeValue;
+  }
+
+  public void setAttributeValue(String attributeValue) {
+    this.attributeValue = attributeValue;
+  }
+}

--- a/lib/kadai-core/src/test/java/acceptance/user/query/UserNPlusOneAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/user/query/UserNPlusOneAccTest.java
@@ -25,15 +25,21 @@ import io.kadai.common.internal.KadaiEngineImpl;
 import io.kadai.common.test.security.JaasExtension;
 import io.kadai.user.api.UserQueryColumnName;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.executor.CachingExecutor;
 import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.plugin.Intercepts;
 import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Plugin;
 import org.apache.ibatis.plugin.Signature;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
@@ -57,6 +63,18 @@ class UserNPlusOneAccTest extends AbstractAccTest {
     SqlSessionManager sqlSessionManager =
         (SqlSessionManager) sessionManagerField.get(kadaiEngine);
     sqlSessionManager.getConfiguration().addInterceptor(queryCounter);
+  }
+
+  @Test
+  void should_CountNestedMybatisQueries() throws Exception {
+    queryCounter.reset();
+
+    kadaiEngine.getUserService().getUser("user-1-1");
+
+    assertThat(queryCounter.snapshot().statementIds())
+        .contains(
+            "io.kadai.user.internal.UserMapper.findGroupsById",
+            "io.kadai.user.internal.UserMapper.findPermissionsById");
   }
 
   @Test
@@ -157,14 +175,62 @@ class UserNPlusOneAccTest extends AbstractAccTest {
 
   private record QueryStats(int count, List<String> statementIds) {}
 
-  @Intercepts(
-      @Signature(
-          type = Executor.class,
-          method = "query",
-          args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class}))
+  @Intercepts({
+    @Signature(
+        type = Executor.class,
+        method = "query",
+        args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class}),
+    @Signature(
+        type = Executor.class,
+        method = "query",
+        args = {
+          MappedStatement.class,
+          Object.class,
+          RowBounds.class,
+          ResultHandler.class,
+          CacheKey.class,
+          BoundSql.class
+        })
+  })
   private static class QueryCountingInterceptor implements Interceptor {
 
     private final ArrayList<String> statementIds = new ArrayList<>();
+
+    @Override
+    public Object plugin(Object target) {
+      Object plugin = Interceptor.super.plugin(target);
+      // CachingExecutor gives ResultLoader its unproxied wrapper. Route that wrapper through this
+      // proxy so nested six-argument queries are counted as well.
+      Executor executor = unwrapCachingExecutor(target);
+      if (executor != null) {
+        try {
+          Field delegateField = CachingExecutor.class.getDeclaredField("delegate");
+          delegateField.setAccessible(true);
+          ((Executor) delegateField.get(executor)).setExecutorWrapper((Executor) plugin);
+        } catch (ReflectiveOperationException e) {
+          throw new IllegalStateException("Could not instrument the nested-query executor", e);
+        }
+      }
+      return plugin;
+    }
+
+    private static Executor unwrapCachingExecutor(Object target) {
+      Object current = target;
+      try {
+        while (Proxy.isProxyClass(current.getClass())) {
+          InvocationHandler invocationHandler = Proxy.getInvocationHandler(current);
+          if (!(invocationHandler instanceof Plugin)) {
+            return null;
+          }
+          Field targetField = Plugin.class.getDeclaredField("target");
+          targetField.setAccessible(true);
+          current = targetField.get(invocationHandler);
+        }
+      } catch (ReflectiveOperationException e) {
+        throw new IllegalStateException("Could not inspect the MyBatis executor proxy", e);
+      }
+      return current instanceof CachingExecutor ? (Executor) current : null;
+    }
 
     @Override
     public Object intercept(Invocation invocation) throws Throwable {

--- a/lib/kadai-core/src/test/java/acceptance/user/query/UserNPlusOneAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/user/query/UserNPlusOneAccTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package acceptance.user.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import io.kadai.common.internal.KadaiEngineImpl;
+import io.kadai.common.test.security.JaasExtension;
+import io.kadai.user.api.UserQueryColumnName;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Signature;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JaasExtension.class)
+class UserNPlusOneAccTest extends AbstractAccTest {
+
+  private QueryCountingInterceptor queryCounter;
+
+  @BeforeEach
+  void installQueryCounter() throws Exception {
+    queryCounter = new QueryCountingInterceptor();
+
+    Field sessionManagerField = KadaiEngineImpl.class.getDeclaredField("sessionManager");
+    sessionManagerField.setAccessible(true);
+
+    SqlSessionManager sqlSessionManager =
+        (SqlSessionManager) sessionManagerField.get(kadaiEngine);
+    sqlSessionManager.getConfiguration().addInterceptor(queryCounter);
+  }
+
+  @Test
+  void should_UseConstantNumberOfQueries_When_GettingUsersByIds() throws Exception {
+    List<String> userIds =
+        kadaiEngine
+            .getUserService()
+            .createUserQuery()
+            .listValues(UserQueryColumnName.USER_ID, null);
+
+    assertThat(userIds).hasSizeGreaterThanOrEqualTo(10);
+
+    queryCounter.reset();
+    kadaiEngine.getUserService().getUsers(Set.of(userIds.get(0)));
+    QueryStats oneUserStats = queryCounter.snapshot();
+
+    queryCounter.reset();
+    kadaiEngine
+        .getUserService()
+        .getUsers(new LinkedHashSet<>(userIds.subList(0, 10)));
+    QueryStats tenUserStats = queryCounter.snapshot();
+
+    assertThat(tenUserStats.count())
+        .withFailMessage(
+            "Query count must not grow with the number of users.%n"
+                + "1 user: %s%n"
+                + "10 users: %s",
+            oneUserStats,
+            tenUserStats)
+        .isEqualTo(oneUserStats.count())
+        .isLessThanOrEqualTo(4);
+    assertThat(tenUserStats.statementIds())
+        .containsExactly(
+            "io.kadai.user.internal.UserMapper.findByIds",
+            "io.kadai.user.internal.UserMapper.findGroupsByIds",
+            "io.kadai.user.internal.UserMapper.findPermissionsByIds",
+            "io.kadai.user.internal.UserMapper.findDomainsByIds");
+  }
+
+  @Test
+  void should_UseConstantNumberOfQueries_When_QueryingUsers() {
+    List<String> userIds =
+        kadaiEngine
+            .getUserService()
+            .createUserQuery()
+            .listValues(UserQueryColumnName.USER_ID, null);
+
+    assertThat(userIds).hasSizeGreaterThanOrEqualTo(10);
+
+    queryCounter.reset();
+    kadaiEngine.getUserService().createUserQuery().idIn(userIds.get(0)).list();
+    QueryStats oneUserStats = queryCounter.snapshot();
+
+    queryCounter.reset();
+    String[] tenUserIds = userIds.subList(0, 10).toArray(String[]::new);
+    kadaiEngine.getUserService().createUserQuery().idIn(tenUserIds).list();
+    QueryStats tenUserStats = queryCounter.snapshot();
+
+    assertThat(tenUserStats.count())
+        .withFailMessage(
+            "Query count must not grow with the number of users.%n"
+                + "1 user: %s%n"
+                + "10 users: %s",
+            oneUserStats,
+            tenUserStats)
+        .isEqualTo(oneUserStats.count())
+        .isLessThanOrEqualTo(4);
+    assertThat(tenUserStats.statementIds())
+        .containsExactly(
+            "io.kadai.user.internal.UserQueryMapper.queryUsers",
+            "io.kadai.user.internal.UserMapper.findGroupsByIds",
+            "io.kadai.user.internal.UserMapper.findPermissionsByIds",
+            "io.kadai.user.internal.UserMapper.findDomainsByIds");
+  }
+
+  @Test
+  void should_NotRunEnrichmentQueries_When_NoUsersAreFound() {
+    queryCounter.reset();
+
+    List<?> users =
+        kadaiEngine.getUserService().createUserQuery().idIn("definitely-not-existing").list();
+
+    assertThat(users).isEmpty();
+    assertThat(queryCounter.snapshot().statementIds())
+        .containsExactly("io.kadai.user.internal.UserQueryMapper.queryUsers");
+  }
+
+  @Test
+  void should_NotRunEnrichmentQueries_When_NoUsersAreFoundByIds() {
+    queryCounter.reset();
+
+    List<?> users = kadaiEngine.getUserService().getUsers(Set.of("definitely-not-existing"));
+
+    assertThat(users).isEmpty();
+    assertThat(queryCounter.snapshot().statementIds())
+        .containsExactly("io.kadai.user.internal.UserMapper.findByIds");
+  }
+
+  private record QueryStats(int count, List<String> statementIds) {}
+
+  @Intercepts(
+      @Signature(
+          type = Executor.class,
+          method = "query",
+          args = {MappedStatement.class, Object.class, RowBounds.class, ResultHandler.class}))
+  private static class QueryCountingInterceptor implements Interceptor {
+
+    private final ArrayList<String> statementIds = new ArrayList<>();
+
+    @Override
+    public Object intercept(Invocation invocation) throws Throwable {
+      MappedStatement mappedStatement = (MappedStatement) invocation.getArgs()[0];
+      statementIds.add(mappedStatement.getId());
+      return invocation.proceed();
+    }
+
+    void reset() {
+      statementIds.clear();
+    }
+
+    QueryStats snapshot() {
+      return new QueryStats(statementIds.size(), List.copyOf(statementIds));
+    }
+  }
+}


### PR DESCRIPTION
I would usually provide benchmarks but this is far too obvious in terms of improvement.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: