### PR TITLE
Closes #2180 - Replace `TaskQuery` 1:n Joins with `EXISTS` where possible

### DIFF
--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
@@ -2655,6 +2655,49 @@ class TaskQueryImplAccTest {
 
       @WithAccessId(user = "user-1-1")
       @Test
+      void should_CountTaskOnce_When_AttachmentJoinIsOnlyNeededForOrdering() throws Exception {
+        String channel = "exists-count-with-attachment-ordering";
+
+        Attachment attachment = createAttachment().channel(channel).build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .attachments(attachment, attachment.copy())
+                .buildAndStoreAsSummary(taskService);
+
+        TaskQuery query =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .orderByAttachmentChannel(null);
+
+        long count = query.count();
+        List<TaskSummary> tasks = query.list();
+
+        assertThat(count).isOne();
+        assertThat(tasks).containsExactly(task);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_CountTaskOnce_When_OnlyOrderingByAttachment() throws Exception {
+        Attachment attachment =
+            createAttachment().channel("exists-count-order-only-channel").build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .attachments(attachment, attachment.copy())
+                .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService.createTaskQuery().idIn(task.getId()).orderByAttachmentChannel(null).count();
+
+        assertThat(count).isOne();
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
       void should_CountTaskOnce_When_MultipleSecondaryObjectReferencesMatchFilter()
           throws Exception {
         String company = "exists-count-sor-company";

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
@@ -41,6 +41,7 @@ import io.kadai.task.api.CallbackState;
 import io.kadai.task.api.TaskCustomField;
 import io.kadai.task.api.TaskCustomIntField;
 import io.kadai.task.api.TaskQuery;
+import io.kadai.task.api.TaskQueryColumnName;
 import io.kadai.task.api.TaskService;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.api.WildcardSearchField;
@@ -2606,6 +2607,260 @@ class TaskQueryImplAccTest {
             taskService.createTaskQuery().workbasketIdIn(wb.getId()).reopenedEquals(false).list();
 
         assertThat(list).containsExactly(taskSummary2);
+      }
+    }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    class RelatedEntityExistsFiltering {
+
+      WorkbasketSummary wb;
+
+      @WithAccessId(user = "user-1-1")
+      @BeforeAll
+      void setup() throws Exception {
+        wb = createWorkbasketWithPermission();
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_CountTaskOnce_When_MultipleAttachmentsMatchFilter() throws Exception {
+        String channel = "exists-count-attachment-channel";
+
+        Attachment attachment1 = createAttachment().channel(channel).build();
+        Attachment attachment2 = createAttachment().channel(channel).build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .attachments(attachment1, attachment2)
+                .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .count();
+
+        List<TaskSummary> tasks =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .list();
+
+        assertThat(count).isOne();
+        assertThat(tasks).containsExactly(task);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_CountTaskOnce_When_MultipleSecondaryObjectReferencesMatchFilter()
+          throws Exception {
+        String company = "exists-count-sor-company";
+
+        ObjectReference sor1 =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("exists-count-sor-type-1")
+                .value("exists-count-sor-value-1")
+                .build();
+
+        ObjectReference sor2 =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("exists-count-sor-type-2")
+                .value("exists-count-sor-value-2")
+                .build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .objectReferences(sor1, sor2)
+                .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .sorCompanyIn(company)
+                .count();
+
+        List<TaskSummary> tasks =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .sorCompanyIn(company)
+                .list();
+
+        assertThat(count).isOne();
+        assertThat(tasks).containsExactly(task);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_RequireSameAttachmentToMatchAllAttachmentFilters() throws Exception {
+        String channel = "exists-same-attachment-channel";
+        String reference = "exists-same-attachment-reference";
+
+        Attachment channelOnly =
+            createAttachment()
+                .channel(channel)
+                .objectReference(
+                    defaultTestObjectReference()
+                        .value("exists-same-attachment-wrong-reference")
+                        .build())
+                .build();
+
+        Attachment referenceOnly =
+            createAttachment()
+                .channel("exists-same-attachment-wrong-channel")
+                .objectReference(defaultTestObjectReference().value(reference).build())
+                .build();
+
+        TaskSummary splitAcrossAttachments =
+            taskInWorkbasket(wb)
+                .attachments(channelOnly, referenceOnly)
+                .buildAndStoreAsSummary(taskService);
+
+        Attachment matchingAttachment =
+            createAttachment()
+                .channel(channel)
+                .objectReference(defaultTestObjectReference().value(reference).build())
+                .build();
+
+        TaskSummary sameAttachmentMatches =
+            taskInWorkbasket(wb)
+                .attachments(matchingAttachment)
+                .buildAndStoreAsSummary(taskService);
+
+        List<TaskSummary> tasks =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .attachmentReferenceValueIn(reference)
+                .list();
+
+        assertThat(tasks)
+            .containsExactly(sameAttachmentMatches)
+            .doesNotContain(splitAcrossAttachments);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_RequireSameSecondaryObjectReferenceToMatchAllSorFilters() throws Exception {
+        String company = "exists-same-sor-company";
+        String value = "exists-same-sor-value";
+
+        ObjectReference companyOnly =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("exists-same-sor-type")
+                .value("exists-same-sor-wrong-value")
+                .build();
+
+        ObjectReference valueOnly =
+            ObjectReferenceBuilder.newObjectReference()
+                .company("exists-same-sor-wrong-company")
+                .type("exists-same-sor-type")
+                .value(value)
+                .build();
+
+        TaskSummary splitAcrossObjectReferences =
+            taskInWorkbasket(wb)
+                .objectReferences(companyOnly, valueOnly)
+                .buildAndStoreAsSummary(taskService);
+
+        ObjectReference matchingSor =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("exists-same-sor-type")
+                .value(value)
+                .build();
+
+        TaskSummary sameObjectReferenceMatches =
+            taskInWorkbasket(wb)
+                .objectReferences(matchingSor)
+                .buildAndStoreAsSummary(taskService);
+
+        List<TaskSummary> tasks =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .sorCompanyIn(company)
+                .sorValueIn(value)
+                .list();
+
+        assertThat(tasks)
+            .containsExactly(sameObjectReferenceMatches)
+            .doesNotContain(splitAcrossObjectReferences);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_FilterJoinedAttachmentRow_When_ListingAttachmentValues() throws Exception {
+        String matchingReference = "exists-list-values-attachment-reference";
+
+        Attachment matchingAttachment =
+            createAttachment()
+                .channel("exists-list-values-matching-channel")
+                .objectReference(defaultTestObjectReference().value(matchingReference).build())
+                .build();
+
+        Attachment nonMatchingAttachment =
+            createAttachment()
+                .channel("exists-list-values-non-matching-channel")
+                .objectReference(
+                    defaultTestObjectReference()
+                        .value("exists-list-values-other-reference")
+                        .build())
+                .build();
+
+        taskInWorkbasket(wb)
+            .attachments(matchingAttachment, nonMatchingAttachment)
+            .buildAndStoreAsSummary(taskService);
+
+        List<String> channels =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentReferenceValueIn(matchingReference)
+                .listValues(TaskQueryColumnName.A_CHANNEL, null);
+
+        assertThat(channels).containsExactly("exists-list-values-matching-channel");
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_FilterJoinedSorRow_When_ListingSorValues() throws Exception {
+        String matchingCompany = "exists-list-values-sor-company";
+
+        ObjectReference matchingSor =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(matchingCompany)
+                .type("exists-list-values-sor-type")
+                .value("exists-list-values-matching-sor-value")
+                .build();
+
+        ObjectReference nonMatchingSor =
+            ObjectReferenceBuilder.newObjectReference()
+                .company("exists-list-other-sor-company")
+                .type("exists-list-values-sor-type")
+                .value("exists-list-values-non-matching-sor-value")
+                .build();
+
+        taskInWorkbasket(wb)
+            .objectReferences(matchingSor, nonMatchingSor)
+            .buildAndStoreAsSummary(taskService);
+
+        List<String> values =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .sorCompanyIn(matchingCompany)
+                .listValues(TaskQueryColumnName.O_VALUE, null);
+
+        assertThat(values).containsExactly("exists-list-values-matching-sor-value");
       }
     }
 

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
@@ -2741,6 +2741,55 @@ class TaskQueryImplAccTest {
 
       @WithAccessId(user = "user-1-1")
       @Test
+      void should_CountTaskOnce_When_MultipleAttachmentsAndSorsMatch() throws Exception {
+        String channel = "count-derived-combined-channel";
+        String company = "count-derived-combined-company";
+
+        Attachment attachment1 = createAttachment().channel(channel).build();
+        Attachment attachment2 = createAttachment().channel(channel).build();
+
+        ObjectReference sor1 =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("count-derived-combined-type-1")
+                .value("count-derived-combined-value-1")
+                .build();
+
+        ObjectReference sor2 =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("count-derived-combined-type-2")
+                .value("count-derived-combined-value-2")
+                .build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .attachments(attachment1, attachment2)
+                .objectReferences(sor1, sor2)
+                .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .sorCompanyIn(company)
+                .count();
+
+        assertThat(count).isOne();
+
+        assertThat(
+                taskService
+                    .createTaskQuery()
+                    .workbasketIdIn(wb.getId())
+                    .attachmentChannelIn(channel)
+                    .sorCompanyIn(company)
+                    .list())
+            .containsExactly(task);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
       void should_RequireSameAttachmentToMatchAllAttachmentFilters() throws Exception {
         String channel = "exists-same-attachment-channel";
         String reference = "exists-same-attachment-reference";
@@ -2791,6 +2840,43 @@ class TaskQueryImplAccTest {
 
       @WithAccessId(user = "user-1-1")
       @Test
+      void should_RequireSameAttachmentToMatchAllAttachmentFilters_When_Counting()
+          throws Exception {
+        String channel = "count-same-attachment-channel";
+        String reference = "count-same-attachment-reference";
+
+        Attachment channelOnly =
+            createAttachment()
+                .channel(channel)
+                .objectReference(
+                    defaultTestObjectReference()
+                        .value("count-same-attachment-wrong-reference")
+                        .build())
+                .build();
+
+        Attachment referenceOnly =
+            createAttachment()
+                .channel("count-same-attachment-wrong-channel")
+                .objectReference(defaultTestObjectReference().value(reference).build())
+                .build();
+
+        taskInWorkbasket(wb)
+            .attachments(channelOnly, referenceOnly)
+            .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .attachmentReferenceValueIn(reference)
+                .count();
+
+        assertThat(count).isZero();
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
       void should_RequireSameSecondaryObjectReferenceToMatchAllSorFilters() throws Exception {
         String company = "exists-same-sor-company";
         String value = "exists-same-sor-value";
@@ -2837,6 +2923,42 @@ class TaskQueryImplAccTest {
         assertThat(tasks)
             .containsExactly(sameObjectReferenceMatches)
             .doesNotContain(splitAcrossObjectReferences);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
+      void should_RequireSameSecondaryObjectReferenceToMatchAllSorFilters_When_Counting()
+          throws Exception {
+        String company = "count-same-sor-company";
+        String value = "count-same-sor-value";
+
+        ObjectReference companyOnly =
+            ObjectReferenceBuilder.newObjectReference()
+                .company(company)
+                .type("count-same-sor-type")
+                .value("count-same-sor-wrong-value")
+                .build();
+
+        ObjectReference valueOnly =
+            ObjectReferenceBuilder.newObjectReference()
+                .company("count-same-sor-wrong-company")
+                .type("count-same-sor-type")
+                .value(value)
+                .build();
+
+        taskInWorkbasket(wb)
+            .objectReferences(companyOnly, valueOnly)
+            .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .sorCompanyIn(company)
+                .sorValueIn(value)
+                .count();
+
+        assertThat(count).isZero();
       }
 
       @WithAccessId(user = "user-1-1")

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
@@ -2655,6 +2655,36 @@ class TaskQueryImplAccTest {
 
       @WithAccessId(user = "user-1-1")
       @Test
+      void should_CountTaskOnce_When_ThreeAttachmentsMatchRawCountJoin() throws Exception {
+        String channel = "count-distinct-three-attachments";
+
+        Attachment attachment = createAttachment().channel(channel).build();
+
+        TaskSummary task =
+            taskInWorkbasket(wb)
+                .attachments(attachment, attachment.copy(), attachment.copy())
+                .buildAndStoreAsSummary(taskService);
+
+        long count =
+            taskService
+                .createTaskQuery()
+                .workbasketIdIn(wb.getId())
+                .attachmentChannelIn(channel)
+                .count();
+
+        assertThat(count).isOne();
+
+        assertThat(
+                taskService
+                    .createTaskQuery()
+                    .workbasketIdIn(wb.getId())
+                    .attachmentChannelIn(channel)
+                    .list())
+            .containsExactly(task);
+      }
+
+      @WithAccessId(user = "user-1-1")
+      @Test
       void should_CountTaskOnce_When_AttachmentJoinIsOnlyNeededForOrdering() throws Exception {
         String channel = "exists-count-with-attachment-ordering";
 

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -81,6 +81,9 @@ public class TaskQueryImpl implements TaskQuery {
   private boolean joinWithSecondaryObjectReferences = false;
   private boolean joinWithClassifications = false;
   private boolean joinWithAttachmentClassifications = false;
+  private boolean filterByAttachments = false;
+  private boolean filterByAttachmentClassifications = false;
+  private boolean filterBySecondaryObjectReferences = false;
   private boolean joinWithWorkbaskets = false;
   private boolean addAttachmentColumnsToSelectClauseForOrdering = false;
   private boolean addClassificationNameToSelectClauseForOrdering = false;
@@ -1170,6 +1173,7 @@ public class TaskQueryImpl implements TaskQuery {
               + "in order to group by sor.");
     }
     groupBySor = type;
+    joinWithSecondaryObjectReferences = true;
     return sorTypeIn(type);
   }
 
@@ -1193,14 +1197,12 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery attachmentClassificationIdIn(String... attachmentClassificationIds) {
-    joinWithAttachments = true;
     this.attachmentClassificationIdIn = attachmentClassificationIds;
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationIdNotIn(String... attachmentClassificationIds) {
-    joinWithAttachments = true;
     this.attachmentClassificationIdNotIn = attachmentClassificationIds;
     return this;
   }
@@ -1217,28 +1219,24 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery attachmentClassificationKeyIn(String... attachmentClassificationKeys) {
-    joinWithAttachments = true;
     this.attachmentClassificationKeyIn = attachmentClassificationKeys;
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationKeyNotIn(String... attachmentClassificationKeys) {
-    joinWithAttachments = true;
     this.attachmentClassificationKeyNotIn = attachmentClassificationKeys;
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationKeyLike(String... attachmentClassificationKeys) {
-    joinWithAttachments = true;
     this.attachmentClassificationKeyLike = toLowerCopy(attachmentClassificationKeys);
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationKeyNotLike(String... attachmentClassificationKeys) {
-    joinWithAttachments = true;
     this.attachmentClassificationKeyNotLike = toLowerCopy(attachmentClassificationKeys);
     return this;
   }
@@ -1255,28 +1253,24 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery attachmentClassificationNameIn(String... attachmentClassificationNames) {
-    joinWithAttachmentClassifications = true;
     this.attachmentClassificationNameIn = attachmentClassificationNames;
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationNameNotIn(String... attachmentClassificationNames) {
-    joinWithAttachmentClassifications = true;
     this.attachmentClassificationNameNotIn = attachmentClassificationNames;
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationNameLike(String... attachmentClassificationNames) {
-    joinWithAttachmentClassifications = true;
     this.attachmentClassificationNameLike = toLowerCopy(attachmentClassificationNames);
     return this;
   }
 
   @Override
   public TaskQuery attachmentClassificationNameNotLike(String... attachmentClassificationNames) {
-    joinWithAttachmentClassifications = true;
     this.attachmentClassificationNameNotLike = toLowerCopy(attachmentClassificationNames);
     return this;
   }
@@ -1293,28 +1287,24 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery attachmentChannelIn(String... attachmentChannels) {
-    joinWithAttachments = true;
     this.attachmentChannelIn = attachmentChannels;
     return this;
   }
 
   @Override
   public TaskQuery attachmentChannelNotIn(String... attachmentChannels) {
-    joinWithAttachments = true;
     this.attachmentChannelNotIn = attachmentChannels;
     return this;
   }
 
   @Override
   public TaskQuery attachmentChannelLike(String... attachmentChannels) {
-    joinWithAttachments = true;
     this.attachmentChannelLike = toLowerCopy(attachmentChannels);
     return this;
   }
 
   @Override
   public TaskQuery attachmentChannelNotLike(String... attachmentChannels) {
-    joinWithAttachments = true;
     this.attachmentChannelNotLike = toLowerCopy(attachmentChannels);
     return this;
   }
@@ -1331,28 +1321,24 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery attachmentReferenceValueIn(String... referenceValues) {
-    joinWithAttachments = true;
     this.attachmentReferenceIn = referenceValues;
     return this;
   }
 
   @Override
   public TaskQuery attachmentReferenceValueNotIn(String... referenceValues) {
-    joinWithAttachments = true;
     this.attachmentReferenceNotIn = referenceValues;
     return this;
   }
 
   @Override
   public TaskQuery attachmentReferenceValueLike(String... referenceValues) {
-    joinWithAttachments = true;
     this.attachmentReferenceLike = toLowerCopy(referenceValues);
     return this;
   }
 
   @Override
   public TaskQuery attachmentReferenceValueNotLike(String... referenceValues) {
-    joinWithAttachments = true;
     this.attachmentReferenceNotLike = toLowerCopy(referenceValues);
     return this;
   }
@@ -1370,7 +1356,6 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public TaskQuery attachmentReceivedWithin(TimeInterval... receivedIn) {
     validateAllTimeIntervals(receivedIn);
-    joinWithAttachments = true;
     this.attachmentReceivedWithin = receivedIn;
     return this;
   }
@@ -1378,7 +1363,6 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public TaskQuery attachmentNotReceivedWithin(TimeInterval... receivedNotIn) {
     validateAllTimeIntervals(receivedNotIn);
-    joinWithAttachments = true;
     this.attachmentReceivedNotWithin = receivedNotIn;
     return this;
   }
@@ -1395,7 +1379,6 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery withoutAttachment() {
-    this.joinWithAttachments = true;
     this.withoutAttachment = true;
     return this;
   }
@@ -1434,68 +1417,57 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery secondaryObjectReferenceIn(ObjectReference... objectReferences) {
-    this.joinWithSecondaryObjectReferences = true;
     this.secondaryObjectReferences = objectReferences;
     return this;
   }
 
   public TaskQuery sorCompanyIn(String... companies) {
-    joinWithSecondaryObjectReferences = true;
     sorCompanyIn = companies;
     return this;
   }
 
   public TaskQuery sorCompanyLike(String... companies) {
-    joinWithSecondaryObjectReferences = true;
     sorCompanyLike = toLowerCopy(companies);
     return this;
   }
 
   public TaskQuery sorSystemIn(String... systems) {
-    joinWithSecondaryObjectReferences = true;
     sorSystemIn = systems;
     return this;
   }
 
   public TaskQuery sorSystemLike(String... systems) {
-    joinWithSecondaryObjectReferences = true;
     sorSystemLike = toLowerCopy(systems);
     return this;
   }
 
   public TaskQuery sorSystemInstanceIn(String... systemInstances) {
-    joinWithSecondaryObjectReferences = true;
     sorSystemInstanceIn = systemInstances;
     return this;
   }
 
   public TaskQuery sorSystemInstanceLike(String... systemInstances) {
-    joinWithSecondaryObjectReferences = true;
     sorSystemInstanceLike = toLowerCopy(systemInstances);
     return this;
   }
 
   public TaskQuery sorTypeIn(String... types) {
-    joinWithSecondaryObjectReferences = true;
     sorTypeIn = types;
     return this;
   }
 
   public TaskQuery sorTypeLike(String... types) {
-    joinWithSecondaryObjectReferences = true;
     sorTypeLike = toLowerCopy(types);
     return this;
   }
 
   @Override
   public TaskQuery sorValueIn(String... values) {
-    joinWithSecondaryObjectReferences = true;
     sorValueIn = values;
     return this;
   }
 
   public TaskQuery sorValueLike(String... values) {
-    joinWithSecondaryObjectReferences = true;
     sorValueLike = toLowerCopy(values);
     return this;
   }
@@ -2299,12 +2271,61 @@ public class TaskQueryImpl implements TaskQuery {
     return DB.getDB(this.kadaiEngine.getSqlSession().getConfiguration().getDatabaseId());
   }
 
+  private void setupRelatedEntityFilterParameters() {
+    filterByAttachmentClassifications =
+        attachmentClassificationNameIn != null
+            || hasElements(attachmentClassificationNameNotIn)
+            || attachmentClassificationNameLike != null
+            || attachmentClassificationNameNotLike != null;
+
+    filterByAttachments =
+        attachmentClassificationIdIn != null
+            || hasElements(attachmentClassificationIdNotIn)
+            || attachmentClassificationKeyIn != null
+            || hasElements(attachmentClassificationKeyNotIn)
+            || attachmentClassificationKeyLike != null
+            || attachmentClassificationKeyNotLike != null
+            || filterByAttachmentClassifications
+            || attachmentChannelIn != null
+            || hasElements(attachmentChannelNotIn)
+            || attachmentChannelLike != null
+            || attachmentChannelNotLike != null
+            || attachmentReferenceIn != null
+            || hasElements(attachmentReferenceNotIn)
+            || attachmentReferenceLike != null
+            || attachmentReferenceNotLike != null
+            || attachmentReceivedWithin != null
+            || attachmentReceivedNotWithin != null;
+
+    filterBySecondaryObjectReferences =
+        secondaryObjectReferences != null
+            || sorCompanyIn != null
+            || sorCompanyLike != null
+            || sorSystemIn != null
+            || sorSystemLike != null
+            || sorSystemInstanceIn != null
+            || sorSystemInstanceLike != null
+            || sorTypeIn != null
+            || sorTypeLike != null
+            || sorValueIn != null
+            || sorValueLike != null;
+  }
+
+  private static boolean hasElements(Object[] values) {
+    return values != null && values.length > 0;
+  }
+
   private void setupJoinAndOrderParameters() {
+    setupRelatedEntityFilterParameters();
+
     // if classificationName or attachmentClassificationName are added to the result set, and
     // multiple
     // attachments exist, the addition of these attribute may increase the result set.
     // in order to have the same result set independent of sorting yes or no,
     // we add the add... flags whenever we join with classification or attachmentClassification
+    if (joinWithAttachments && filterByAttachmentClassifications) {
+      joinWithAttachmentClassifications = true;
+    }
     if (joinWithAttachmentClassifications) {
       joinWithAttachments = true;
       addAttachmentClassificationNameToSelectClauseForOrdering = true;

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -2167,46 +2167,14 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public long count() {
     Long rowCount;
-
-    boolean originalJoinWithAttachments = joinWithAttachments;
-    boolean originalJoinWithAttachmentClassifications = joinWithAttachmentClassifications;
-    boolean originalJoinWithSecondaryObjectReferences = joinWithSecondaryObjectReferences;
-    boolean originalAddAttachmentClassificationNameToSelectClauseForOrdering =
-        addAttachmentClassificationNameToSelectClauseForOrdering;
-    boolean originalUseDistinctKeyword = useDistinctKeyword;
-
     try {
       kadaiEngine.openConnection();
       checkOpenReadAndReadTasksPermissionForSpecifiedWorkbaskets();
       setupAccessIds();
-
-      if (!groupByPor && groupBySor == null) {
-        // count() has no ORDER BY / related-column projection.
-        // Force attachment/SOR filters back to their EXISTS branch.
-        joinWithAttachments = false;
-        joinWithAttachmentClassifications = false;
-        joinWithSecondaryObjectReferences = false;
-
-        // setupJoinAndOrderParameters() would otherwise recreate the attachment join
-        // for orderByAttachmentClassificationName(...).
-        addAttachmentClassificationNameToSelectClauseForOrdering = false;
-
-        // Recompute DISTINCT for the actual count shape instead of retaining state
-        // from an earlier operation on the same mutable query.
-        useDistinctKeyword = false;
-      }
-
       setupJoinAndOrderParameters();
       rowCount = kadaiEngine.getSqlSession().selectOne(getLinkToCounterTaskScript(), this);
       return (rowCount == null) ? 0L : rowCount;
     } finally {
-      joinWithAttachments = originalJoinWithAttachments;
-      joinWithAttachmentClassifications = originalJoinWithAttachmentClassifications;
-      joinWithSecondaryObjectReferences = originalJoinWithSecondaryObjectReferences;
-      addAttachmentClassificationNameToSelectClauseForOrdering =
-          originalAddAttachmentClassificationNameToSelectClauseForOrdering;
-      useDistinctKeyword = originalUseDistinctKeyword;
-
       kadaiEngine.returnConnection();
     }
   }

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -2167,14 +2167,46 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public long count() {
     Long rowCount;
+
+    boolean originalJoinWithAttachments = joinWithAttachments;
+    boolean originalJoinWithAttachmentClassifications = joinWithAttachmentClassifications;
+    boolean originalJoinWithSecondaryObjectReferences = joinWithSecondaryObjectReferences;
+    boolean originalAddAttachmentClassificationNameToSelectClauseForOrdering =
+        addAttachmentClassificationNameToSelectClauseForOrdering;
+    boolean originalUseDistinctKeyword = useDistinctKeyword;
+
     try {
       kadaiEngine.openConnection();
       checkOpenReadAndReadTasksPermissionForSpecifiedWorkbaskets();
       setupAccessIds();
+
+      if (!groupByPor && groupBySor == null) {
+        // count() has no ORDER BY / related-column projection.
+        // Force attachment/SOR filters back to their EXISTS branch.
+        joinWithAttachments = false;
+        joinWithAttachmentClassifications = false;
+        joinWithSecondaryObjectReferences = false;
+
+        // setupJoinAndOrderParameters() would otherwise recreate the attachment join
+        // for orderByAttachmentClassificationName(...).
+        addAttachmentClassificationNameToSelectClauseForOrdering = false;
+
+        // Recompute DISTINCT for the actual count shape instead of retaining state
+        // from an earlier operation on the same mutable query.
+        useDistinctKeyword = false;
+      }
+
       setupJoinAndOrderParameters();
       rowCount = kadaiEngine.getSqlSession().selectOne(getLinkToCounterTaskScript(), this);
       return (rowCount == null) ? 0L : rowCount;
     } finally {
+      joinWithAttachments = originalJoinWithAttachments;
+      joinWithAttachmentClassifications = originalJoinWithAttachmentClassifications;
+      joinWithSecondaryObjectReferences = originalJoinWithSecondaryObjectReferences;
+      addAttachmentClassificationNameToSelectClauseForOrdering =
+          originalAddAttachmentClassificationNameToSelectClauseForOrdering;
+      useDistinctKeyword = originalUseDistinctKeyword;
+
       kadaiEngine.returnConnection();
     }
   }

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -196,17 +196,24 @@ public class TaskQuerySqlProvider {
         + groupByPorIfActive()
         + groupBySorIfActive()
         + "FROM TASK t "
+        + "<choose>"
+        + "<when test=\"groupByPor or groupBySor != null\">"
         + "<if test=\"joinWithAttachments\">"
         + "LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID "
         + "</if>"
         + "<if test=\"joinWithSecondaryObjectReferences\">"
         + "LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID "
         + "</if>"
-        + "<if test=\"joinWithClassifications\">"
-        + "LEFT JOIN CLASSIFICATION c ON t.CLASSIFICATION_ID = c.ID "
-        + "</if>"
         + "<if test=\"joinWithAttachmentClassifications\">"
         + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
+        + "</if>"
+        + "</when>"
+        + "<otherwise>"
+        + countRelatedEntityFilterJoins()
+        + "</otherwise>"
+        + "</choose>"
+        + "<if test=\"joinWithClassifications\">"
+        + "LEFT JOIN CLASSIFICATION c ON t.CLASSIFICATION_ID = c.ID "
         + "</if>"
         + "<if test=\"joinWithUserInfo\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
@@ -216,7 +223,14 @@ public class TaskQuerySqlProvider {
         + "</if>"
         + OPENING_WHERE_TAG
         + checkForAuthorization()
+        + "<choose>"
+        + "<when test=\"groupByPor or groupBySor != null\">"
         + commonTaskWhereStatement()
+        + "</when>"
+        + "<otherwise>"
+        + commonTaskWhereStatement(false)
+        + "</otherwise>"
+        + "</choose>"
         + CLOSING_WHERE_TAG
         + closeOuterClauseForGroupByPor()
         + closeOuterClauseForGroupBySor()
@@ -225,21 +239,32 @@ public class TaskQuerySqlProvider {
 
   @SuppressWarnings("unused")
   public static String countQueryTasksDb2() {
+    String distinctKeyword =
+        "<if test=\"useDistinctKeyword and (groupByPor or groupBySor != null)\">DISTINCT</if> ";
+
     return OPENING_SCRIPT_TAG
         + "WITH X (ID, WORKBASKET_ID) AS ("
-        + "SELECT <if test=\"useDistinctKeyword\">DISTINCT</if> "
+        + "SELECT "
+        + distinctKeyword
         + "t.ID, t.WORKBASKET_ID FROM TASK t "
+        + "<choose>"
+        + "<when test=\"groupByPor or groupBySor != null\">"
         + "<if test=\"joinWithAttachments\">"
         + "LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID "
         + "</if>"
-        + "<if test=\"joinWithClassifications\">"
-        + "LEFT JOIN CLASSIFICATION c ON t.CLASSIFICATION_ID = c.ID "
+        + "<if test=\"joinWithSecondaryObjectReferences\">"
+        + "LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID "
         + "</if>"
         + "<if test=\"joinWithAttachmentClassifications\">"
         + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
         + "</if>"
-        + "<if test=\"joinWithSecondaryObjectReferences\">"
-        + "LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID "
+        + "</when>"
+        + "<otherwise>"
+        + countRelatedEntityFilterJoins()
+        + "</otherwise>"
+        + "</choose>"
+        + "<if test=\"joinWithClassifications\">"
+        + "LEFT JOIN CLASSIFICATION c ON t.CLASSIFICATION_ID = c.ID "
         + "</if>"
         + "<if test=\"joinWithUserInfo\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
@@ -248,7 +273,14 @@ public class TaskQuerySqlProvider {
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
+        + "<choose>"
+        + "<when test=\"groupByPor or groupBySor != null\">"
         + commonTaskWhereStatement()
+        + "</when>"
+        + "<otherwise>"
+        + commonTaskWhereStatement(false)
+        + "</otherwise>"
+        + "</choose>"
         + CLOSING_WHERE_TAG
         + "), Y (ID, FLAG) AS ("
         + "SELECT ID, ("
@@ -267,6 +299,31 @@ public class TaskQuerySqlProvider {
         + "FROM X ) SELECT COUNT(*) "
         + "FROM Y WHERE FLAG = 1 with UR"
         + CLOSING_SCRIPT_TAG;
+  }
+
+  private static String countRelatedEntityFilterJoins() {
+    String attachmentFilterStatement = commonAttachmentFilterWhereStatement().toString();
+    String sorFilterStatement = commonSecondaryObjectReferenceFilterWhereStatement().toString();
+
+    return "<if test='filterByAttachments'>"
+        + "INNER JOIN ("
+        + "SELECT DISTINCT a.TASK_ID "
+        + "FROM ATTACHMENT a "
+        + "<if test='filterByAttachmentClassifications'>"
+        + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
+        + "</if>"
+        + "WHERE 1 = 1 "
+        + attachmentFilterStatement
+        + ") filtered_a ON filtered_a.TASK_ID = t.ID "
+        + "</if>"
+        + "<if test='filterBySecondaryObjectReferences'>"
+        + "INNER JOIN ("
+        + "SELECT DISTINCT o.TASK_ID "
+        + "FROM OBJECT_REFERENCE o "
+        + "WHERE 1 = 1 "
+        + sorFilterStatement
+        + ") filtered_o ON filtered_o.TASK_ID = t.ID "
+        + "</if>";
   }
 
   @SuppressWarnings("unused")
@@ -641,6 +698,10 @@ public class TaskQuerySqlProvider {
   }
 
   private static StringBuilder commonTaskWhereStatement() {
+    return commonTaskWhereStatement(true);
+  }
+
+  private static StringBuilder commonTaskWhereStatement(boolean includeRelatedEntityFilters) {
     StringBuilder sb = new StringBuilder();
     commonWhereClauses("businessProcessId", "t.BUSINESS_PROCESS_ID", sb);
     commonWhereClauses("classificationCategory", "CLASSIFICATION_CATEGORY", sb);
@@ -728,10 +789,14 @@ public class TaskQuerySqlProvider {
             + "LIKE #{wildcardSearchValueLike}"
             + "</foreach>)"
             + "</if> ");
-    sb.append(attachmentWhereStatement());
+    if (includeRelatedEntityFilters) {
+      sb.append(attachmentWhereStatement());
+    }
     sb.append(withoutAttachmentWhereStatement());
     sb.append(commonTaskObjectReferenceWhereStatement());
-    sb.append(secondaryObjectReferenceWhereStatement());
+    if (includeRelatedEntityFilters) {
+      sb.append(secondaryObjectReferenceWhereStatement());
+    }
     return sb;
   }
 }

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -186,7 +186,8 @@ public class TaskQuerySqlProvider {
   @SuppressWarnings("unused")
   public static String countQueryTasks() {
     return OPENING_SCRIPT_TAG
-        + "SELECT COUNT(*) "
+        + "SELECT "
+        + countExpression()
         + "<if test=\"groupByPor or groupBySor != null\"> "
         + "FROM (SELECT t.ID, t.POR_VALUE "
         + "</if> "
@@ -209,7 +210,7 @@ public class TaskQuerySqlProvider {
         + "</if>"
         + "</when>"
         + "<otherwise>"
-        + countRelatedEntityFilterJoins()
+        + countRelatedEntityJoins()
         + "</otherwise>"
         + "</choose>"
         + "<if test=\"joinWithClassifications\">"
@@ -229,6 +230,7 @@ public class TaskQuerySqlProvider {
         + "</when>"
         + "<otherwise>"
         + commonTaskWhereStatement(false)
+        + countSingleRelatedEntityWhereStatement()
         + "</otherwise>"
         + "</choose>"
         + CLOSING_WHERE_TAG
@@ -239,13 +241,10 @@ public class TaskQuerySqlProvider {
 
   @SuppressWarnings("unused")
   public static String countQueryTasksDb2() {
-    String distinctKeyword =
-        "<if test=\"useDistinctKeyword and (groupByPor or groupBySor != null)\">DISTINCT</if> ";
-
     return OPENING_SCRIPT_TAG
         + "WITH X (ID, WORKBASKET_ID) AS ("
         + "SELECT "
-        + distinctKeyword
+        + db2CountDistinctKeyword()
         + "t.ID, t.WORKBASKET_ID FROM TASK t "
         + "<choose>"
         + "<when test=\"groupByPor or groupBySor != null\">"
@@ -260,7 +259,7 @@ public class TaskQuerySqlProvider {
         + "</if>"
         + "</when>"
         + "<otherwise>"
-        + countRelatedEntityFilterJoins()
+        + countRelatedEntityJoins()
         + "</otherwise>"
         + "</choose>"
         + "<if test=\"joinWithClassifications\">"
@@ -279,6 +278,7 @@ public class TaskQuerySqlProvider {
         + "</when>"
         + "<otherwise>"
         + commonTaskWhereStatement(false)
+        + countSingleRelatedEntityWhereStatement()
         + "</otherwise>"
         + "</choose>"
         + CLOSING_WHERE_TAG
@@ -301,7 +301,24 @@ public class TaskQuerySqlProvider {
         + CLOSING_SCRIPT_TAG;
   }
 
-  private static String countRelatedEntityFilterJoins() {
+  private static String countRelatedEntityJoins() {
+    return "<choose>"
+        + "<when test='filterByAttachments and !filterBySecondaryObjectReferences'>"
+        + "INNER JOIN ATTACHMENT a ON a.TASK_ID = t.ID "
+        + "<if test='filterByAttachmentClassifications'>"
+        + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
+        + "</if>"
+        + "</when>"
+        + "<when test='!filterByAttachments and filterBySecondaryObjectReferences'>"
+        + "INNER JOIN OBJECT_REFERENCE o ON o.TASK_ID = t.ID "
+        + "</when>"
+        + "<when test='filterByAttachments and filterBySecondaryObjectReferences'>"
+        + countDeduplicatedRelatedEntityJoins()
+        + "</when>"
+        + "</choose>";
+  }
+
+  private static String countDeduplicatedRelatedEntityJoins() {
     String attachmentFilterStatement = commonAttachmentFilterWhereStatement().toString();
     String sorFilterStatement = commonSecondaryObjectReferenceFilterWhereStatement().toString();
 
@@ -324,6 +341,45 @@ public class TaskQuerySqlProvider {
         + sorFilterStatement
         + ") filtered_o ON filtered_o.TASK_ID = t.ID "
         + "</if>";
+  }
+
+  private static String countSingleRelatedEntityWhereStatement() {
+    String attachmentFilterStatement = commonAttachmentFilterWhereStatement().toString();
+    String sorFilterStatement = commonSecondaryObjectReferenceFilterWhereStatement().toString();
+
+    return "<choose>"
+        + "<when test='filterByAttachments and !filterBySecondaryObjectReferences'>"
+        + attachmentFilterStatement
+        + "</when>"
+        + "<when test='!filterByAttachments and filterBySecondaryObjectReferences'>"
+        + sorFilterStatement
+        + "</when>"
+        + "</choose>";
+  }
+
+  private static String exactlyOneRelatedEntityFilterExpression() {
+    return "((filterByAttachments and !filterBySecondaryObjectReferences) "
+        + "or (!filterByAttachments and filterBySecondaryObjectReferences))";
+  }
+
+  private static String countExpression() {
+    return "<choose>"
+        + "<when test='!groupByPor and groupBySor == null and "
+        + exactlyOneRelatedEntityFilterExpression()
+        + "'>COUNT(DISTINCT t.ID)</when>"
+        + "<otherwise>COUNT(*)</otherwise>"
+        + "</choose> ";
+  }
+
+  private static String db2CountDistinctKeyword() {
+    return "<choose>"
+        + "<when test='groupByPor or groupBySor != null'>"
+        + "<if test='useDistinctKeyword'>DISTINCT</if>"
+        + "</when>"
+        + "<when test='"
+        + exactlyOneRelatedEntityFilterExpression()
+        + "'>DISTINCT</when>"
+        + "</choose> ";
   }
 
   @SuppressWarnings("unused")

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -554,12 +554,94 @@ public class TaskQuerySqlProvider {
     whereNotLike(filter + "NotLike", channel, sb);
   }
 
-  private static StringBuilder commonTaskWhereStatement() {
+  private static StringBuilder commonAttachmentFilterWhereStatement() {
     StringBuilder sb = new StringBuilder();
+
     commonWhereClauses("attachmentChannel", "a.CHANNEL", sb);
     commonWhereClauses("attachmentClassificationKey", "a.CLASSIFICATION_KEY", sb);
     commonWhereClauses("attachmentClassificationName", "ac.NAME", sb);
     commonWhereClauses("attachmentReference", "a.REF_VALUE", sb);
+
+    whereIn("attachmentClassificationIdIn", "a.CLASSIFICATION_ID", sb);
+    whereNotIn("attachmentClassificationIdNotIn", "a.CLASSIFICATION_ID", sb);
+
+    whereInInterval("attachmentReceivedWithin", "a.RECEIVED", sb);
+    whereNotInInterval("attachmentReceivedNotWithin", "a.RECEIVED", sb);
+
+    return sb;
+  }
+
+  private static String attachmentWhereStatement() {
+    String filterStatement = commonAttachmentFilterWhereStatement().toString();
+
+    return "<if test='filterByAttachments'>"
+        + "<choose>"
+        + "<when test='joinWithAttachments'>"
+        + filterStatement
+        + "</when>"
+        + "<otherwise>"
+        + "AND EXISTS ("
+        + "SELECT 1 FROM ATTACHMENT a "
+        + "<if test='filterByAttachmentClassifications'>"
+        + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
+        + "</if>"
+        + "WHERE a.TASK_ID = t.ID "
+        + filterStatement
+        + ") "
+        + "</otherwise>"
+        + "</choose>"
+        + "</if> ";
+  }
+
+  private static String withoutAttachmentWhereStatement() {
+    return "<if test='withoutAttachment'>"
+        + "AND NOT EXISTS ("
+        + "SELECT 1 FROM ATTACHMENT a_without "
+        + "WHERE a_without.TASK_ID = t.ID"
+        + ") "
+        + "</if> ";
+  }
+
+  private static StringBuilder commonSecondaryObjectReferenceFilterWhereStatement() {
+    StringBuilder sb = new StringBuilder();
+
+    whereIn("sorCompanyIn", "o.COMPANY", sb);
+    whereLike("sorCompanyLike", "o.COMPANY", sb);
+    whereIn("sorSystemIn", "o.SYSTEM", sb);
+    whereLike("sorSystemLike", "o.SYSTEM", sb);
+    whereIn("sorSystemInstanceIn", "o.SYSTEM_INSTANCE", sb);
+    whereLike("sorSystemInstanceLike", "o.SYSTEM_INSTANCE", sb);
+    whereIn("sorTypeIn", "o.TYPE", sb);
+    whereLike("sorTypeLike", "o.TYPE", sb);
+    whereIn("sorValueIn", "o.VALUE", sb);
+    whereLike("sorValueLike", "o.VALUE", sb);
+
+    sb.append(commonTaskSecondaryObjectReferencesWhereStatement());
+
+    return sb;
+  }
+
+  private static String secondaryObjectReferenceWhereStatement() {
+    String filterStatement = commonSecondaryObjectReferenceFilterWhereStatement().toString();
+
+    return "<if test='filterBySecondaryObjectReferences'>"
+        + "<choose>"
+        + "<when test='joinWithSecondaryObjectReferences'>"
+        + filterStatement
+        + "</when>"
+        + "<otherwise>"
+        + "AND EXISTS ("
+        + "SELECT 1 FROM OBJECT_REFERENCE o "
+        + "WHERE o.TASK_ID = t.ID "
+        + filterStatement
+        + ") "
+        + "</otherwise>"
+        + "</choose>"
+        + "</if> ";
+  }
+
+  private static StringBuilder commonTaskWhereStatement() {
+    StringBuilder sb = new StringBuilder();
     commonWhereClauses("businessProcessId", "t.BUSINESS_PROCESS_ID", sb);
     commonWhereClauses("classificationCategory", "CLASSIFICATION_CATEGORY", sb);
     commonWhereClauses("classificationKey", "t.CLASSIFICATION_KEY", sb);
@@ -575,19 +657,6 @@ public class TaskQuerySqlProvider {
     commonWhereClauses("porType", "t.POR_TYPE", sb);
     commonWhereClauses("porValue", "t.POR_VALUE", sb);
 
-    whereIn("sorCompanyIn", "o.COMPANY", sb);
-    whereLike("sorCompanyLike", "o.COMPANY", sb);
-    whereIn("sorSystemIn", "o.SYSTEM", sb);
-    whereLike("sorSystemLike", "o.SYSTEM", sb);
-    whereIn("sorSystemInstanceIn", "o.SYSTEM_INSTANCE", sb);
-    whereLike("sorSystemInstanceLike", "o.SYSTEM_INSTANCE", sb);
-    whereIn("sorTypeIn", "o.TYPE", sb);
-    whereLike("sorTypeLike", "o.TYPE", sb);
-    whereIn("sorValueIn", "o.VALUE", sb);
-    whereLike("sorValueLike", "o.VALUE", sb);
-
-    whereIn("attachmentClassificationIdIn", "a.CLASSIFICATION_ID", sb);
-    whereNotIn("attachmentClassificationIdNotIn", "a.CLASSIFICATION_ID", sb);
     whereIn("callbackStateIn", "t.CALLBACK_STATE", sb);
     whereNotIn("callbackStateNotIn", "t.CALLBACK_STATE", sb);
     whereIn("classificationIdIn", "t.CLASSIFICATION_ID", sb);
@@ -611,8 +680,6 @@ public class TaskQuerySqlProvider {
     whereLike("noteLike", "t.NOTE", sb);
     whereNotLike("noteNotLike", "t.NOTE", sb);
 
-    whereInInterval("attachmentReceivedWithin", "a.RECEIVED", sb);
-    whereNotInInterval("attachmentReceivedNotWithin", "a.RECEIVED", sb);
     whereInInterval("claimedWithin", "t.CLAIMED", sb);
     whereNotInInterval("claimedNotWithin", "t.CLAIMED", sb);
     whereInInterval("completedWithin", "t.COMPLETED", sb);
@@ -661,9 +728,10 @@ public class TaskQuerySqlProvider {
             + "LIKE #{wildcardSearchValueLike}"
             + "</foreach>)"
             + "</if> ");
-    sb.append("<if test='withoutAttachment'> AND a.ID IS NULL</if> ");
+    sb.append(attachmentWhereStatement());
+    sb.append(withoutAttachmentWhereStatement());
     sb.append(commonTaskObjectReferenceWhereStatement());
-    sb.append(commonTaskSecondaryObjectReferencesWhereStatement());
+    sb.append(secondaryObjectReferenceWhereStatement());
     return sb;
   }
 }

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
@@ -139,6 +139,22 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "admin")
   @Test
+  void should_UseExistsForCount_When_AttachmentJoinIsOnlyNeededForOrdering() {
+    taskService
+        .createTaskQuery()
+        .attachmentChannelIn("exists-count-sql-shape-channel")
+        .orderByAttachmentChannel(ASCENDING)
+        .count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
   void should_KeepAttachmentJoin_When_AttachmentIsNeededForProjection() {
     taskService
         .createTaskQuery()

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package acceptance.task.query;
+
+import static io.kadai.common.api.BaseQuery.SortDirection.ASCENDING;
+import static io.kadai.task.api.TaskQueryColumnName.A_CHANNEL;
+import static io.kadai.task.api.TaskQueryColumnName.O_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
+import io.kadai.common.internal.KadaiEngineImpl;
+import io.kadai.common.test.security.JaasExtension;
+import io.kadai.common.test.security.WithAccessId;
+import java.lang.reflect.Field;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(JaasExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
+
+  @BeforeAll
+  void setupSqlCapture() throws Exception {
+    Field sessionManagerField = KadaiEngineImpl.class.getDeclaredField("sessionManager");
+    sessionManagerField.setAccessible(true);
+    SqlSessionManager sessionManager = (SqlSessionManager) sessionManagerField.get(kadaiEngine);
+    sessionManager
+        .getConfiguration()
+        .addInterceptor(new ParameterizedQuerySqlCaptureInterceptor());
+  }
+
+  @BeforeEach
+  void resetCapturedSql() {
+    ParameterizedQuerySqlCaptureInterceptor.resetCapturedSql();
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_UseExistsWithoutAttachmentJoin_When_AttachmentIsOnlyUsedForFiltering() {
+    taskService
+        .createTaskQuery()
+        .attachmentChannelIn("exists-sql-shape-channel")
+        .list();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .doesNotContain("SELECT DISTINCT");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinAttachmentClassificationInsideExists_When_FilteringByAttachmentName() {
+    taskService
+        .createTaskQuery()
+        .attachmentClassificationNameLike("exists-sql-shape%")
+        .list();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains(
+            "EXISTS (SELECT 1 FROM ATTACHMENT a "
+                + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
+                + "WHERE a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_UseExistsWithoutSorJoin_When_SorIsOnlyUsedForFiltering() {
+    taskService
+        .createTaskQuery()
+        .sorCompanyIn("exists-sql-shape-company")
+        .sorValueIn("exists-sql-shape-value")
+        .list();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("EXISTS (SELECT 1 FROM OBJECT_REFERENCE o WHERE o.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID")
+        .doesNotContain("SELECT DISTINCT");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_UseNotExistsWithoutAttachmentJoin_When_QueryingWithoutAttachment() {
+    taskService.createTaskQuery().withoutAttachment().list();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains(
+            "NOT EXISTS (SELECT 1 FROM ATTACHMENT a_without "
+                + "WHERE a_without.TASK_ID = t.ID)")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_KeepAttachmentJoin_When_AttachmentIsNeededForOrdering() {
+    taskService
+        .createTaskQuery()
+        .attachmentChannelIn("exists-sql-shape-channel")
+        .orderByAttachmentChannel(ASCENDING)
+        .list();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_KeepAttachmentJoin_When_AttachmentIsNeededForProjection() {
+    taskService
+        .createTaskQuery()
+        .attachmentReferenceValueIn("exists-sql-shape-reference")
+        .listValues(A_CHANNEL, ASCENDING);
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_KeepSorJoin_When_SorIsNeededForProjection() {
+    taskService
+        .createTaskQuery()
+        .sorCompanyIn("exists-sql-shape-company")
+        .listValues(O_VALUE, ASCENDING);
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM OBJECT_REFERENCE o WHERE o.TASK_ID = t.ID");
+  }
+
+  private String normalizedCapturedSql() {
+    String sql = ParameterizedQuerySqlCaptureInterceptor.getCapturedSql();
+    assertThat(sql).isNotNull();
+    return sql.replaceAll("\\s+", " ").trim();
+  }
+}

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
@@ -139,55 +139,81 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "admin")
   @Test
-  void should_UseDeduplicatedAttachmentJoinForCount_When_FilteringByAttachment() {
+  void should_UseCountDistinctWithRawAttachmentJoin_When_OnlyAttachmentIsFiltered() {
     taskService
         .createTaskQuery()
-        .attachmentChannelIn("count-derived-attachment-channel")
+        .attachmentChannelIn("count-distinct-attachment-channel")
         .orderByAttachmentChannel(ASCENDING)
         .count();
 
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
-        .contains("INNER JOIN (SELECT DISTINCT a.TASK_ID FROM ATTACHMENT a")
-        .contains("filtered_a ON filtered_a.TASK_ID = t.ID")
-        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .satisfies(this::assertCountDistinctTaskIds)
+        .contains("INNER JOIN ATTACHMENT a ON a.TASK_ID = t.ID")
+        .contains("a.CHANNEL")
+        .doesNotContain("SELECT DISTINCT a.TASK_ID")
+        .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID")
         .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
   }
 
   @WithAccessId(user = "admin")
   @Test
-  void should_UseDeduplicatedSorJoinForCount_When_FilteringBySor() {
+  void should_UseCountDistinctWithRawSorJoin_When_OnlySorIsFiltered() {
     taskService
         .createTaskQuery()
-        .sorCompanyIn("count-derived-sor-company")
-        .sorValueIn("count-derived-sor-value")
+        .sorCompanyIn("count-distinct-sor-company")
+        .sorValueIn("count-distinct-sor-value")
         .count();
 
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
-        .contains("INNER JOIN (SELECT DISTINCT o.TASK_ID FROM OBJECT_REFERENCE o")
-        .contains("filtered_o ON filtered_o.TASK_ID = t.ID")
-        .doesNotContain("LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID")
+        .satisfies(this::assertCountDistinctTaskIds)
+        .contains("INNER JOIN OBJECT_REFERENCE o ON o.TASK_ID = t.ID")
+        .contains("o.COMPANY")
+        .contains("o.VALUE")
+        .doesNotContain("SELECT DISTINCT o.TASK_ID")
+        .doesNotContain("filtered_o ON filtered_o.TASK_ID = t.ID")
         .doesNotContain("EXISTS (SELECT 1 FROM OBJECT_REFERENCE o WHERE o.TASK_ID = t.ID");
   }
 
   @WithAccessId(user = "admin")
   @Test
-  void should_JoinAttachmentClassificationInsideDeduplicatedCountRelation() {
+  void should_JoinAttachmentClassificationWithRawAttachmentCount() {
     taskService
         .createTaskQuery()
-        .attachmentClassificationNameLike("count-derived-classification%")
+        .attachmentClassificationNameLike("count-distinct-classification%")
         .count();
 
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
-        .contains("INNER JOIN (SELECT DISTINCT a.TASK_ID FROM ATTACHMENT a")
+        .satisfies(this::assertCountDistinctTaskIds)
+        .contains("INNER JOIN ATTACHMENT a ON a.TASK_ID = t.ID")
         .contains("LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID")
+        .contains("ac.NAME")
+        .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_UseSeparateDeduplicatedRelations_When_AttachmentAndSorAreBothFiltered() {
+    taskService
+        .createTaskQuery()
+        .attachmentChannelIn("count-both-channel")
+        .sorCompanyIn("count-both-company")
+        .count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("COUNT(*)")
+        .contains("SELECT DISTINCT a.TASK_ID")
         .contains("filtered_a ON filtered_a.TASK_ID = t.ID")
-        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+        .contains("SELECT DISTINCT o.TASK_ID")
+        .contains("filtered_o ON filtered_o.TASK_ID = t.ID")
+        .doesNotContain("COUNT(DISTINCT t.ID)");
   }
 
   @WithAccessId(user = "admin")
@@ -198,9 +224,11 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
+        .contains("COUNT(*)")
         .contains(
             "NOT EXISTS (SELECT 1 FROM ATTACHMENT a_without "
                 + "WHERE a_without.TASK_ID = t.ID)")
+        .doesNotContain("COUNT(DISTINCT t.ID)")
         .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID")
         .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
   }
@@ -213,6 +241,8 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
+        .contains("COUNT(*)")
+        .doesNotContain("COUNT(DISTINCT t.ID)")
         .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID")
         .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
         .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
@@ -252,5 +282,17 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
     String sql = ParameterizedQuerySqlCaptureInterceptor.getCapturedSql();
     assertThat(sql).isNotNull();
     return sql.replaceAll("\\s+", " ").trim();
+  }
+
+  private void assertCountDistinctTaskIds(String sql) {
+    if (isDb2()) {
+      assertThat(sql).contains("SELECT DISTINCT t.ID, t.WORKBASKET_ID");
+    } else {
+      assertThat(sql).contains("COUNT(DISTINCT t.ID)");
+    }
+  }
+
+  private boolean isDb2() {
+    return "DB2".equals(System.getenv("DB"));
   }
 }

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksRelatedEntityExistsAccTest.java
@@ -139,18 +139,83 @@ class QueryTasksRelatedEntityExistsAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "admin")
   @Test
-  void should_UseExistsForCount_When_AttachmentJoinIsOnlyNeededForOrdering() {
+  void should_UseDeduplicatedAttachmentJoinForCount_When_FilteringByAttachment() {
     taskService
         .createTaskQuery()
-        .attachmentChannelIn("exists-count-sql-shape-channel")
+        .attachmentChannelIn("count-derived-attachment-channel")
         .orderByAttachmentChannel(ASCENDING)
         .count();
 
     String sql = normalizedCapturedSql();
 
     assertThat(sql)
-        .contains("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID")
+        .contains("INNER JOIN (SELECT DISTINCT a.TASK_ID FROM ATTACHMENT a")
+        .contains("filtered_a ON filtered_a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_UseDeduplicatedSorJoinForCount_When_FilteringBySor() {
+    taskService
+        .createTaskQuery()
+        .sorCompanyIn("count-derived-sor-company")
+        .sorValueIn("count-derived-sor-value")
+        .count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("INNER JOIN (SELECT DISTINCT o.TASK_ID FROM OBJECT_REFERENCE o")
+        .contains("filtered_o ON filtered_o.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM OBJECT_REFERENCE o WHERE o.TASK_ID = t.ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinAttachmentClassificationInsideDeduplicatedCountRelation() {
+    taskService
+        .createTaskQuery()
+        .attachmentClassificationNameLike("count-derived-classification%")
+        .count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains("INNER JOIN (SELECT DISTINCT a.TASK_ID FROM ATTACHMENT a")
+        .contains("LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID")
+        .contains("filtered_a ON filtered_a.TASK_ID = t.ID")
         .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_KeepNotExistsForCount_When_QueryingWithoutAttachment() {
+    taskService.createTaskQuery().withoutAttachment().count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .contains(
+            "NOT EXISTS (SELECT 1 FROM ATTACHMENT a_without "
+                + "WHERE a_without.TASK_ID = t.ID)")
+        .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotJoinAttachmentForCount_When_AttachmentIsOnlyUsedForOrdering() {
+    taskService.createTaskQuery().orderByAttachmentChannel(ASCENDING).count();
+
+    String sql = normalizedCapturedSql();
+
+    assertThat(sql)
+        .doesNotContain("filtered_a ON filtered_a.TASK_ID = t.ID")
+        .doesNotContain("LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID")
+        .doesNotContain("EXISTS (SELECT 1 FROM ATTACHMENT a WHERE a.TASK_ID = t.ID");
   }
 
   @WithAccessId(user = "admin")


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: