### PR TITLE
Closes #2181 - Avoid unnecessary user-info joins in task-queries

### DIFF
--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplGroupByAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryImplGroupByAccTest.java
@@ -284,6 +284,19 @@ class TaskQueryImplGroupByAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "user-1-1")
   @Test
+  void should_Count_When_GroupingByPorAndOrderingByOwnerLongName() {
+    Long numberOfTasks =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .orderByOwnerLongName(SortDirection.ASCENDING)
+            .count();
+    assertThat(numberOfTasks).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
   void should_GroupBySor_When_OrderingByName() {
     List<TaskSummary> list =
         taskService
@@ -325,6 +338,19 @@ class TaskQueryImplGroupByAccTest implements KadaiConfigurationModifier {
             .createTaskQuery()
             .workbasketIdIn(defaultWorkbasket.getId())
             .groupBySor("SecondType")
+            .count();
+    assertThat(numberOfTasks).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_Count_When_GroupingBySorAndOrderingByCreatorLongName() {
+    Long numberOfTasks =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .orderByCreatorLongName(SortDirection.ASCENDING)
             .count();
     assertThat(numberOfTasks).isEqualTo(1);
   }

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
@@ -91,6 +91,55 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "admin")
   @Test
+  void should_JoinOwnerUserInfo_When_GroupedCountOrdersByOwnerLongName() {
+    String sql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .groupByPor()
+                    .orderByOwnerLongName(ASCENDING)
+                    .count());
+
+    assertThat(sql).contains("user_info owner_info").doesNotContain("user_info creator_info");
+    assertThat(countOccurrences(sql, "user_info owner_info")).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinCreatorUserInfo_When_GroupedCountOrdersByCreatorLongName() {
+    String sql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .groupBySor("SecondType")
+                    .orderByCreatorLongName(ASCENDING)
+                    .count());
+
+    assertThat(sql).contains("user_info creator_info").doesNotContain("user_info owner_info");
+    assertThat(countOccurrences(sql, "user_info creator_info")).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinRequiredUserInfo_When_GroupedCountMixesFilterAndLongNameOrdering() {
+    String sql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .groupByPor()
+                    .ownerLongNameLike("%user-1-1%")
+                    .orderByCreatorLongName(ASCENDING)
+                    .count());
+
+    assertThat(countOccurrences(sql, "user_info owner_info")).isEqualTo(2);
+    assertThat(countOccurrences(sql, "user_info creator_info")).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
   void should_JoinOnlyRequiredUserInfo_When_CountFiltersByLongName() {
     String ownerSql =
         captureSql(() -> taskService.createTaskQuery().ownerLongNameLike("%user-1-1%").count());
@@ -195,16 +244,61 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
     assertThat(countSql).doesNotContain("user_info owner_info", "user_info creator_info");
     assertThat(ownerSortSql)
         .contains("user_info owner_info")
+        .contains("owner_long_name asc")
         .doesNotContain("user_info creator_info");
     assertThat(creatorFilterSql)
         .contains("user_info creator_info")
         .doesNotContain("user_info owner_info");
   }
 
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotLeakGroupedSummaryOrderingIntoGroupCount() {
+    String sql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .groupByPor()
+                    .orderByOwnerLongName(ASCENDING)
+                    .list());
+
+    assertThat(countOccurrences(sql, "user_info owner_info")).isEqualTo(1);
+    assertThat(sql).doesNotContain("user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotRetainLongNameOrdering_WhenScalarValuesReplaceOrdering() {
+    TaskQuery query =
+        taskService.createTaskQuery().groupByPor().orderByOwnerLongName(ASCENDING);
+
+    query.listValues(TaskQueryColumnName.NAME, ASCENDING);
+    String countSql = captureSql(query::count);
+
+    assertThat(countSql).doesNotContain("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_RetainSelectedLongNameOrdering_WhenScalarValuesAreReused() {
+    TaskQuery query = taskService.createTaskQuery().groupByPor();
+
+    query.listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING);
+    String countSql = captureSql(query::count);
+
+    assertThat(countOccurrences(countSql, "user_info owner_info")).isEqualTo(1);
+    assertThat(countSql).doesNotContain("user_info creator_info");
+  }
+
   private String captureSql(Runnable query) {
     SqlCaptureInterceptor.reset();
     query.run();
     return SqlCaptureInterceptor.get().toLowerCase(Locale.ROOT);
+  }
+
+  private int countOccurrences(String value, String substring) {
+    return (value.length() - value.replace(substring, "").length()) / substring.length();
   }
 
   @Nested
@@ -344,6 +438,36 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
                   .nameIn("same-name-for-distinct-test")
                   .listValues(TaskQueryColumnName.NAME, ASCENDING))
           .containsExactly("same-name-for-distinct-test");
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WithAdditionalUserInfoAndGenericTaskQuery implements KadaiConfigurationModifier {
+
+    @KadaiInject InternalKadaiEngine configuredInternalKadaiEngine;
+    @KadaiInject TaskService configuredTaskService;
+
+    @Override
+    public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+      return builder.addAdditionalUserInfo(true).useSpecificDb2Taskquery(false);
+    }
+
+    @BeforeAll
+    void registerSqlCaptureInterceptor() {
+      configuredInternalKadaiEngine
+          .getSqlSession()
+          .getConfiguration()
+          .addInterceptor(new SqlCaptureInterceptor());
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_NotLeakGroupedSummaryEnrichmentIntoGroupCount() {
+      String sql = captureSql(() -> configuredTaskService.createTaskQuery().groupByPor().list());
+
+      assertThat(countOccurrences(sql, "user_info owner_info")).isEqualTo(1);
+      assertThat(countOccurrences(sql, "user_info creator_info")).isEqualTo(1);
     }
   }
 

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
@@ -269,7 +269,7 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "admin")
   @Test
-  void should_NotRetainLongNameOrdering_WhenScalarValuesReplaceOrdering() {
+  void should_NotRetainLongNameOrdering_When_ReplacingWithScalarValues() {
     TaskQuery query =
         taskService.createTaskQuery().groupByPor().orderByOwnerLongName(ASCENDING);
 
@@ -281,7 +281,7 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "admin")
   @Test
-  void should_NotRetainUserInfoJoin_WhenScalarValuesReplaceLongNameOrdering() {
+  void should_NotRetainUserInfoJoin_When_ReplacingLongNameOrderingWithScalarValues() {
     TaskQuery ownerQuery = taskService.createTaskQuery().orderByOwnerLongName(ASCENDING);
     TaskQuery creatorQuery = taskService.createTaskQuery().orderByCreatorLongName(ASCENDING);
 
@@ -296,7 +296,7 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "admin")
   @Test
-  void should_RetainSelectedLongNameOrdering_WhenScalarValuesAreReused() {
+  void should_RetainSelectedLongNameOrdering_When_ReusingScalarValues() {
     TaskQuery query = taskService.createTaskQuery().groupByPor();
 
     query.listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING);

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
@@ -281,6 +281,21 @@ class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
 
   @WithAccessId(user = "admin")
   @Test
+  void should_NotRetainUserInfoJoin_WhenScalarValuesReplaceLongNameOrdering() {
+    TaskQuery ownerQuery = taskService.createTaskQuery().orderByOwnerLongName(ASCENDING);
+    TaskQuery creatorQuery = taskService.createTaskQuery().orderByCreatorLongName(ASCENDING);
+
+    ownerQuery.listValues(TaskQueryColumnName.NAME, ASCENDING);
+    creatorQuery.listValues(TaskQueryColumnName.NAME, ASCENDING);
+    String ownerSummarySql = captureSql(ownerQuery::list);
+    String creatorSummarySql = captureSql(creatorQuery::list);
+
+    assertThat(ownerSummarySql).doesNotContain("user_info owner_info", "user_info creator_info");
+    assertThat(creatorSummarySql).doesNotContain("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
   void should_RetainSelectedLongNameOrdering_WhenScalarValuesAreReused() {
     TaskQuery query = taskService.createTaskQuery().groupByPor();
 

--- a/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
+++ b/lib/kadai-core-test/src/test/java/acceptance/task/query/TaskQueryUserInfoSqlAccTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright [2026] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package acceptance.task.query;
+
+import static io.kadai.common.api.BaseQuery.SortDirection.ASCENDING;
+import static io.kadai.testapi.DefaultTestEntities.defaultTestClassification;
+import static io.kadai.testapi.DefaultTestEntities.defaultTestObjectReference;
+import static io.kadai.testapi.DefaultTestEntities.defaultTestWorkbasket;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kadai.KadaiConfiguration;
+import io.kadai.classification.api.ClassificationService;
+import io.kadai.classification.api.models.ClassificationSummary;
+import io.kadai.common.internal.InternalKadaiEngine;
+import io.kadai.task.api.TaskQuery;
+import io.kadai.task.api.TaskQueryColumnName;
+import io.kadai.task.api.TaskService;
+import io.kadai.testapi.KadaiConfigurationModifier;
+import io.kadai.testapi.KadaiInject;
+import io.kadai.testapi.KadaiIntegrationTest;
+import io.kadai.testapi.builder.TaskBuilder;
+import io.kadai.testapi.security.WithAccessId;
+import io.kadai.workbasket.api.WorkbasketService;
+import io.kadai.workbasket.api.models.WorkbasketSummary;
+import java.sql.Statement;
+import java.util.Locale;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Signature;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@KadaiIntegrationTest
+class TaskQueryUserInfoSqlAccTest implements KadaiConfigurationModifier {
+
+  @KadaiInject InternalKadaiEngine internalKadaiEngine;
+  @KadaiInject TaskService taskService;
+
+  @Override
+  public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+    return builder.useSpecificDb2Taskquery(false);
+  }
+
+  @BeforeAll
+  void registerSqlCaptureInterceptor() {
+    internalKadaiEngine
+        .getSqlSession()
+        .getConfiguration()
+        .addInterceptor(new SqlCaptureInterceptor());
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotJoinUserInfo_When_CountHasNoLongNameFilter() {
+    String sql = captureSql(() -> taskService.createTaskQuery().count());
+
+    assertThat(sql).doesNotContain("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotJoinUserInfo_When_CountOnlySortsByLongName() {
+    String ownerSql =
+        captureSql(() -> taskService.createTaskQuery().orderByOwnerLongName(ASCENDING).count());
+    String creatorSql =
+        captureSql(() -> taskService.createTaskQuery().orderByCreatorLongName(ASCENDING).count());
+
+    assertThat(ownerSql).doesNotContain("user_info owner_info", "user_info creator_info");
+    assertThat(creatorSql).doesNotContain("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinOnlyRequiredUserInfo_When_CountFiltersByLongName() {
+    String ownerSql =
+        captureSql(() -> taskService.createTaskQuery().ownerLongNameLike("%user-1-1%").count());
+    String creatorSql =
+        captureSql(() -> taskService.createTaskQuery().creatorLongNameLike("%user-1-1%").count());
+    String bothSql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .ownerLongNameLike("%user-1-1%")
+                    .creatorLongNameLike("%user-1-1%")
+                    .count());
+
+    assertThat(ownerSql).contains("user_info owner_info").doesNotContain("user_info creator_info");
+    assertThat(creatorSql)
+        .contains("user_info creator_info")
+        .doesNotContain("user_info owner_info");
+    assertThat(bothSql).contains("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_JoinOnlyRequiredUserInfo_When_ListingScalarValues() {
+    String nameSql =
+        captureSql(
+            () -> taskService.createTaskQuery().listValues(TaskQueryColumnName.NAME, ASCENDING));
+    String ownerSql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING));
+    String creatorSql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .listValues(TaskQueryColumnName.CREATOR_LONG_NAME, ASCENDING));
+    String filteredSql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .creatorLongNameLike("%user-1-1%")
+                    .listValues(TaskQueryColumnName.NAME, ASCENDING));
+    String selectedAndFilteredSql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .creatorLongNameLike("%user-1-1%")
+                    .listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING));
+
+    assertThat(nameSql).doesNotContain("user_info owner_info", "user_info creator_info");
+    assertThat(ownerSql).contains("user_info owner_info").doesNotContain("user_info creator_info");
+    assertThat(creatorSql)
+        .contains("user_info creator_info")
+        .doesNotContain("user_info owner_info");
+    assertThat(filteredSql)
+        .contains("user_info creator_info")
+        .doesNotContain("user_info owner_info");
+    assertThat(selectedAndFilteredSql).contains("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_ProjectOnlyRequestedValue_When_ListingOwnerLongNames() {
+    String sql =
+        captureSql(
+            () ->
+                taskService
+                    .createTaskQuery()
+                    .listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING));
+
+    String selectClause = sql.substring(0, sql.indexOf("from task"));
+    assertThat(selectClause).isEqualTo("select distinct owner_info.long_name ");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_NotLeakScalarColumnJoinIntoLaterCount() {
+    TaskQuery query = taskService.createTaskQuery();
+
+    String scalarSql =
+        captureSql(() -> query.listValues(TaskQueryColumnName.OWNER_LONG_NAME, ASCENDING));
+    String countSql = captureSql(query::count);
+
+    assertThat(scalarSql).contains("user_info owner_info");
+    assertThat(countSql).doesNotContain("user_info owner_info", "user_info creator_info");
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_KeepSummaryUserInfoJoin_When_SortingOrFilteringByLongName() {
+    TaskQuery ownerSortQuery = taskService.createTaskQuery().orderByOwnerLongName(ASCENDING);
+    String countSql = captureSql(ownerSortQuery::count);
+    String ownerSortSql = captureSql(ownerSortQuery::list);
+    String creatorFilterSql =
+        captureSql(() -> taskService.createTaskQuery().creatorLongNameLike("%user-1-1%").list());
+
+    assertThat(countSql).doesNotContain("user_info owner_info", "user_info creator_info");
+    assertThat(ownerSortSql)
+        .contains("user_info owner_info")
+        .doesNotContain("user_info creator_info");
+    assertThat(creatorFilterSql)
+        .contains("user_info creator_info")
+        .doesNotContain("user_info owner_info");
+  }
+
+  private String captureSql(Runnable query) {
+    SqlCaptureInterceptor.reset();
+    query.run();
+    return SqlCaptureInterceptor.get().toLowerCase(Locale.ROOT);
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WithSpecificDb2Taskquery implements KadaiConfigurationModifier {
+
+    @KadaiInject InternalKadaiEngine specificInternalKadaiEngine;
+    @KadaiInject TaskService specificTaskService;
+
+    @Override
+    public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+      return builder.addAdditionalUserInfo(false).useSpecificDb2Taskquery(true);
+    }
+
+    @BeforeAll
+    void registerSqlCaptureInterceptor() {
+      specificInternalKadaiEngine
+          .getSqlSession()
+          .getConfiguration()
+          .addInterceptor(new SqlCaptureInterceptor());
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_UseFilterDependenciesForSpecificDb2Count() {
+      String ownerFilterSql =
+          captureSql(
+              () -> specificTaskService.createTaskQuery().ownerLongNameLike("%user-1-1%").count());
+      String ownerSortSql =
+          captureSql(
+              () -> specificTaskService.createTaskQuery().orderByOwnerLongName(ASCENDING).count());
+
+      assertThat(ownerFilterSql)
+          .contains("user_info owner_info")
+          .doesNotContain("user_info creator_info");
+      assertThat(ownerSortSql).doesNotContain("user_info owner_info", "user_info creator_info");
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_UseFilterAndSortDependenciesForSpecificDb2Summary() {
+      String ownerSortSql =
+          captureSql(
+              () -> specificTaskService.createTaskQuery().orderByOwnerLongName(ASCENDING).list());
+      String creatorFilterSql =
+          captureSql(
+              () -> specificTaskService.createTaskQuery().creatorLongNameLike("%user-1-1%").list());
+
+      assertThat(ownerSortSql)
+          .contains("user_info owner_info")
+          .doesNotContain("user_info creator_info");
+      assertThat(creatorFilterSql)
+          .contains("user_info creator_info")
+          .doesNotContain("user_info owner_info");
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WithAdditionalUserInfo implements KadaiConfigurationModifier {
+
+    @KadaiInject InternalKadaiEngine configuredInternalKadaiEngine;
+    @KadaiInject TaskService configuredTaskService;
+    @KadaiInject ClassificationService configuredClassificationService;
+    @KadaiInject WorkbasketService configuredWorkbasketService;
+
+    @Override
+    public KadaiConfiguration.Builder modify(KadaiConfiguration.Builder builder) {
+      return builder.addAdditionalUserInfo(true).useSpecificDb2Taskquery(true);
+    }
+
+    @BeforeAll
+    void registerSqlCaptureInterceptor() {
+      configuredInternalKadaiEngine
+          .getSqlSession()
+          .getConfiguration()
+          .addInterceptor(new SqlCaptureInterceptor());
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_NotJoinUserInfo_When_EnrichmentIsEnabledForCount() {
+      String sql = captureSql(() -> configuredTaskService.createTaskQuery().count());
+
+      assertThat(sql).doesNotContain("user_info owner_info", "user_info creator_info");
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_NotJoinUserInfoOrProjectLongNames_When_EnrichmentIsEnabledForScalarValues() {
+      String sql =
+          captureSql(
+              () ->
+                  configuredTaskService
+                      .createTaskQuery()
+                      .listValues(TaskQueryColumnName.NAME, ASCENDING));
+
+      assertThat(sql).doesNotContain("user_info owner_info", "user_info creator_info");
+      assertThat(sql.substring(0, sql.indexOf("from task"))).isEqualTo("select distinct t.name ");
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_KeepBothUserInfoJoins_When_EnrichmentIsEnabledForSummaryList() {
+      String sql = captureSql(() -> configuredTaskService.createTaskQuery().list());
+
+      assertThat(sql).contains("user_info owner_info", "user_info creator_info");
+    }
+
+    @WithAccessId(user = "admin")
+    @Test
+    void should_PreserveDistinctValues_When_EnrichmentIsEnabled() throws Exception {
+      ClassificationSummary classificationSummary =
+          defaultTestClassification()
+              .buildAndStoreAsSummary(configuredClassificationService, "admin");
+      WorkbasketSummary workbasketSummary =
+          defaultTestWorkbasket().buildAndStoreAsSummary(configuredWorkbasketService, "admin");
+
+      TaskBuilder.newTask()
+          .name("same-name-for-distinct-test")
+          .owner("user-1-1")
+          .classificationSummary(classificationSummary)
+          .primaryObjRef(defaultTestObjectReference().build())
+          .workbasketSummary(workbasketSummary)
+          .buildAndStore(configuredTaskService, "admin");
+      TaskBuilder.newTask()
+          .name("same-name-for-distinct-test")
+          .owner("user-1-2")
+          .classificationSummary(classificationSummary)
+          .primaryObjRef(defaultTestObjectReference().build())
+          .workbasketSummary(workbasketSummary)
+          .buildAndStore(configuredTaskService, "admin");
+
+      assertThat(
+              configuredTaskService
+                  .createTaskQuery()
+                  .nameIn("same-name-for-distinct-test")
+                  .listValues(TaskQueryColumnName.NAME, ASCENDING))
+          .containsExactly("same-name-for-distinct-test");
+    }
+  }
+
+  @Intercepts({
+    @Signature(
+        type = StatementHandler.class,
+        method = "parameterize",
+        args = {Statement.class})
+  })
+  private static class SqlCaptureInterceptor implements Interceptor {
+    private static volatile String sql;
+
+    @Override
+    public Object intercept(Invocation invocation) throws Throwable {
+      sql = ((StatementHandler) invocation.getTarget()).getBoundSql().getSql();
+      return invocation.proceed();
+    }
+
+    static String get() {
+      return sql;
+    }
+
+    static void reset() {
+      sql = null;
+    }
+  }
+}

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -89,6 +89,8 @@ public class TaskQueryImpl implements TaskQuery {
   private boolean addWorkbasketNameToSelectClauseForOrdering = false;
   private boolean joinWithUserInfo;
   private boolean joinWithCreatorUserInfo;
+  private boolean orderByOwnerLongName;
+  private boolean orderByCreatorLongName;
   private boolean groupByPor;
   private String groupBySor;
   private String[] taskId;
@@ -628,6 +630,7 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public TaskQuery orderByCreatorLongName(SortDirection sortDirection) {
     joinWithCreatorUserInfo = true;
+    orderByCreatorLongName = true;
     return (DB.DB2 == getDB()
             && kadaiEngine.getEngine().getConfiguration().isUseSpecificDb2Taskquery())
         ? addOrderCriteria("CREATOR_LONG_NAME", sortDirection)
@@ -2076,6 +2079,7 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public TaskQuery orderByOwnerLongName(SortDirection sortDirection) {
     joinWithUserInfo = true;
+    orderByOwnerLongName = true;
     return (DB.DB2 == getDB()
             && kadaiEngine.getEngine().getConfiguration().isUseSpecificDb2Taskquery())
         ? addOrderCriteria("OWNER_LONG_NAME", sortDirection)
@@ -2132,6 +2136,8 @@ public class TaskQueryImpl implements TaskQuery {
       this.columnName = columnName;
       this.orderByOuter.clear();
       this.orderByInner.clear();
+      this.orderByOwnerLongName = columnName == TaskQueryColumnName.OWNER_LONG_NAME;
+      this.orderByCreatorLongName = columnName == TaskQueryColumnName.CREATOR_LONG_NAME;
       this.addOrderCriteria(columnName.toString(), sortDirection);
       checkForIllegalParamCombinations();
       checkOpenReadAndReadTasksPermissionForSpecifiedWorkbaskets();
@@ -2331,10 +2337,18 @@ public class TaskQueryImpl implements TaskQuery {
   }
 
   public boolean isJoinWithUserInfoForCount() {
-    return hasOwnerLongNameFilter();
+    return hasOwnerLongNameFilter() || (isGroupingActive() && orderByOwnerLongName);
   }
 
   public boolean isJoinWithCreatorUserInfoForCount() {
+    return hasCreatorLongNameFilter() || (isGroupingActive() && orderByCreatorLongName);
+  }
+
+  public boolean isJoinWithUserInfoForGroupCount() {
+    return hasOwnerLongNameFilter();
+  }
+
+  public boolean isJoinWithCreatorUserInfoForGroupCount() {
     return hasCreatorLongNameFilter();
   }
 
@@ -2358,6 +2372,10 @@ public class TaskQueryImpl implements TaskQuery {
         || creatorLongNameNotIn != null
         || creatorLongNameLike != null
         || creatorLongNameNotLike != null;
+  }
+
+  private boolean isGroupingActive() {
+    return groupByPor || groupBySor != null;
   }
 
   private void setupAccessIds() {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -71,6 +71,7 @@ public class TaskQueryImpl implements TaskQuery {
   private final TaskServiceImpl taskService;
   private final List<String> orderByOuter;
   private final List<String> orderByInner;
+  private final boolean addAdditionalUserInfo;
 
   private TaskQueryColumnName columnName;
   private String[] accessIdIn;
@@ -370,9 +371,10 @@ public class TaskQueryImpl implements TaskQuery {
     this.filterByAccessIdIn = true;
     this.withoutAttachment = false;
     this.lockResults = 0;
-    this.joinWithUserInfo = kadaiEngine.getEngine().getConfiguration().isAddAdditionalUserInfo();
-    this.joinWithCreatorUserInfo =
+    this.addAdditionalUserInfo =
         kadaiEngine.getEngine().getConfiguration().isAddAdditionalUserInfo();
+    this.joinWithUserInfo = false;
+    this.joinWithCreatorUserInfo = false;
   }
 
   @Override
@@ -2151,13 +2153,6 @@ public class TaskQueryImpl implements TaskQuery {
         joinWithSecondaryObjectReferences = true;
       }
 
-      if (columnName == TaskQueryColumnName.OWNER_LONG_NAME) {
-        joinWithUserInfo = true;
-      }
-      if (columnName == TaskQueryColumnName.CREATOR_LONG_NAME) {
-        joinWithCreatorUserInfo = true;
-      }
-
       setupJoinAndOrderParameters();
       result = kadaiEngine.getSqlSession().selectList(LINK_TO_VALUE_MAPPER, this);
       return result;
@@ -2263,7 +2258,9 @@ public class TaskQueryImpl implements TaskQuery {
       throw new IllegalArgumentException(
           "The params \"lockResultsEquals\" and \"selectAndClaim\"" + " cannot be used together!");
     }
-    if ((joinWithUserInfo || joinWithCreatorUserInfo) && lockResults != null && lockResults != 0) {
+    if ((isJoinWithUserInfoForTaskSummary() || isJoinWithCreatorUserInfoForTaskSummary())
+        && lockResults != null
+        && lockResults != 0) {
       throw new IllegalArgumentException(
           "The params \"lockResultsEquals\" and \"joinWithUserInfo\"/\"joinWithCreatorUserInfo\""
               + " cannot be used together!");
@@ -2323,6 +2320,44 @@ public class TaskQueryImpl implements TaskQuery {
     if (joinWithAttachments || joinWithClassifications || joinWithSecondaryObjectReferences) {
       useDistinctKeyword = true;
     }
+  }
+
+  public boolean isJoinWithUserInfoForTaskSummary() {
+    return addAdditionalUserInfo || joinWithUserInfo;
+  }
+
+  public boolean isJoinWithCreatorUserInfoForTaskSummary() {
+    return addAdditionalUserInfo || joinWithCreatorUserInfo;
+  }
+
+  public boolean isJoinWithUserInfoForCount() {
+    return hasOwnerLongNameFilter();
+  }
+
+  public boolean isJoinWithCreatorUserInfoForCount() {
+    return hasCreatorLongNameFilter();
+  }
+
+  public boolean isJoinWithUserInfoForColumnValues() {
+    return columnName == TaskQueryColumnName.OWNER_LONG_NAME || hasOwnerLongNameFilter();
+  }
+
+  public boolean isJoinWithCreatorUserInfoForColumnValues() {
+    return columnName == TaskQueryColumnName.CREATOR_LONG_NAME || hasCreatorLongNameFilter();
+  }
+
+  private boolean hasOwnerLongNameFilter() {
+    return ownerLongNameIn != null
+        || ownerLongNameNotIn != null
+        || ownerLongNameLike != null
+        || ownerLongNameNotLike != null;
+  }
+
+  private boolean hasCreatorLongNameFilter() {
+    return creatorLongNameIn != null
+        || creatorLongNameNotIn != null
+        || creatorLongNameLike != null
+        || creatorLongNameNotLike != null;
   }
 
   private void setupAccessIds() {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -2329,11 +2329,11 @@ public class TaskQueryImpl implements TaskQuery {
   }
 
   public boolean isJoinWithUserInfoForTaskSummary() {
-    return addAdditionalUserInfo || joinWithUserInfo;
+    return addAdditionalUserInfo || hasOwnerLongNameFilter() || orderByOwnerLongName;
   }
 
   public boolean isJoinWithCreatorUserInfoForTaskSummary() {
-    return addAdditionalUserInfo || joinWithCreatorUserInfo;
+    return addAdditionalUserInfo || hasCreatorLongNameFilter() || orderByCreatorLongName;
   }
 
   public boolean isJoinWithUserInfoForCount() {

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQueryImpl.java
@@ -87,8 +87,6 @@ public class TaskQueryImpl implements TaskQuery {
   private boolean addClassificationNameToSelectClauseForOrdering = false;
   private boolean addAttachmentClassificationNameToSelectClauseForOrdering = false;
   private boolean addWorkbasketNameToSelectClauseForOrdering = false;
-  private boolean joinWithUserInfo;
-  private boolean joinWithCreatorUserInfo;
   private boolean orderByOwnerLongName;
   private boolean orderByCreatorLongName;
   private boolean groupByPor;
@@ -375,8 +373,6 @@ public class TaskQueryImpl implements TaskQuery {
     this.lockResults = 0;
     this.addAdditionalUserInfo =
         kadaiEngine.getEngine().getConfiguration().isAddAdditionalUserInfo();
-    this.joinWithUserInfo = false;
-    this.joinWithCreatorUserInfo = false;
   }
 
   @Override
@@ -596,28 +592,24 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery creatorLongNameIn(String... longNames) {
-    joinWithCreatorUserInfo = true;
     this.creatorLongNameIn = longNames;
     return this;
   }
 
   @Override
   public TaskQuery creatorLongNameNotIn(String... longNames) {
-    joinWithCreatorUserInfo = true;
     this.creatorLongNameNotIn = longNames;
     return this;
   }
 
   @Override
   public TaskQuery creatorLongNameLike(String... longNames) {
-    joinWithCreatorUserInfo = true;
     this.creatorLongNameLike = toLowerCopy(longNames);
     return this;
   }
 
   @Override
   public TaskQuery creatorLongNameNotLike(String... longNames) {
-    joinWithCreatorUserInfo = true;
     this.creatorLongNameNotLike = toLowerCopy(longNames);
     return this;
   }
@@ -629,7 +621,6 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery orderByCreatorLongName(SortDirection sortDirection) {
-    joinWithCreatorUserInfo = true;
     orderByCreatorLongName = true;
     return (DB.DB2 == getDB()
             && kadaiEngine.getEngine().getConfiguration().isUseSpecificDb2Taskquery())
@@ -977,28 +968,24 @@ public class TaskQueryImpl implements TaskQuery {
   }
 
   public TaskQuery ownerLongNameIn(String... longNames) {
-    joinWithUserInfo = true;
     this.ownerLongNameIn = longNames;
     return this;
   }
 
   @Override
   public TaskQuery ownerLongNameNotIn(String... longNames) {
-    joinWithUserInfo = true;
     this.ownerLongNameNotIn = longNames;
     return this;
   }
 
   @Override
   public TaskQuery ownerLongNameLike(String... longNames) {
-    joinWithUserInfo = true;
     this.ownerLongNameLike = toLowerCopy(longNames);
     return this;
   }
 
   @Override
   public TaskQuery ownerLongNameNotLike(String... longNames) {
-    joinWithUserInfo = true;
     this.ownerLongNameNotLike = toLowerCopy(longNames);
     return this;
   }
@@ -2078,7 +2065,6 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskQuery orderByOwnerLongName(SortDirection sortDirection) {
-    joinWithUserInfo = true;
     orderByOwnerLongName = true;
     return (DB.DB2 == getDB()
             && kadaiEngine.getEngine().getConfiguration().isUseSpecificDb2Taskquery())

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -84,10 +84,8 @@ public class TaskQuerySqlProvider {
         + commonTaskWhereStatement()
         + "<if test='selectAndClaim == true'> AND t.STATE = 'READY' </if>"
         + CLOSING_WHERE_TAG
-        + closeOuterClauseForGroupByPor(
-            "joinWithUserInfoForTaskSummary", "joinWithCreatorUserInfoForTaskSummary")
-        + closeOuterClauseForGroupBySor(
-            "joinWithUserInfoForTaskSummary", "joinWithCreatorUserInfoForTaskSummary")
+        + closeOuterClauseForGroupByPor()
+        + closeOuterClauseForGroupBySor()
         + "<if test='!orderByOuter.isEmpty()'>"
         + "ORDER BY <foreach item='item' collection='orderByOuter' separator=',' >${item}</foreach>"
         + "</if> "
@@ -217,10 +215,8 @@ public class TaskQuerySqlProvider {
         + checkForAuthorization()
         + commonTaskWhereStatement()
         + CLOSING_WHERE_TAG
-        + closeOuterClauseForGroupByPor(
-            "joinWithUserInfoForCount", "joinWithCreatorUserInfoForCount")
-        + closeOuterClauseForGroupBySor(
-            "joinWithUserInfoForCount", "joinWithCreatorUserInfoForCount")
+        + closeOuterClauseForGroupByPor()
+        + closeOuterClauseForGroupBySor()
         + CLOSING_SCRIPT_TAG;
   }
 
@@ -426,8 +422,7 @@ public class TaskQuerySqlProvider {
     return "<if test=\"groupByPor or groupBySor != null\"> " + "SELECT * FROM (" + "</if> ";
   }
 
-  private static String closeOuterClauseForGroupByPor(
-      String ownerUserInfoProperty, String creatorUserInfoProperty) {
+  private static String closeOuterClauseForGroupByPor() {
     return "<if test=\"groupByPor\"> "
         + ") t LEFT JOIN"
         + " (SELECT POR_VALUE as PVALUE, COUNT(POR_VALUE) AS R_COUNT "
@@ -448,14 +443,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\""
-        + ownerUserInfoProperty
-        + "\">"
+        + "<if test=\"joinWithUserInfoForGroupCount\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\""
-        + creatorUserInfoProperty
-        + "\">"
+        + "<if test=\"joinWithCreatorUserInfoForGroupCount\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -469,8 +460,7 @@ public class TaskQuerySqlProvider {
         + "</if> ";
   }
 
-  private static String closeOuterClauseForGroupBySor(
-      String ownerUserInfoProperty, String creatorUserInfoProperty) {
+  private static String closeOuterClauseForGroupBySor() {
     return "<if test='groupBySor != null'> "
         + ") t LEFT JOIN"
         + " (SELECT o.VALUE, COUNT(o.VALUE) AS R_COUNT "
@@ -488,14 +478,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\""
-        + ownerUserInfoProperty
-        + "\">"
+        + "<if test=\"joinWithUserInfoForGroupCount\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\""
-        + creatorUserInfoProperty
-        + "\">"
+        + "<if test=\"joinWithCreatorUserInfoForGroupCount\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG

--- a/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
+++ b/lib/kadai-core/src/main/java/io/kadai/task/internal/TaskQuerySqlProvider.java
@@ -45,19 +45,16 @@ public class TaskQuerySqlProvider {
         + openOuterClauseForGroupByPorOrSor()
         + "SELECT <if test=\"useDistinctKeyword\">DISTINCT</if> "
         + commonSelectFields()
-        + "<if test='groupBySor != null'>, o.VALUE as SOR_VALUE </if>"
-        + "<if test=\"addAttachmentColumnsToSelectClauseForOrdering\">"
-        + ", a.CLASSIFICATION_ID as ACLASSIFICATION_ID, "
-        + "a.CLASSIFICATION_KEY as ACLASSIFICATION_KEY, a.CHANNEL as ACHANNEL, "
-        + "a.REF_VALUE as AREF_VALUE, a.RECEIVED as ARECEIVED"
-        + "</if>"
-        + "<if test=\"addClassificationNameToSelectClauseForOrdering\">, c.NAME as CNAME </if>"
-        + "<if test=\"addAttachmentClassificationNameToSelectClauseForOrdering\">, "
-        + "ac.NAME as ACNAME </if>"
-        + "<if test=\"addWorkbasketNameToSelectClauseForOrdering\">, w.NAME as WNAME </if>"
-        + "<if test=\"joinWithUserInfo\">, owner_info.LONG_NAME AS OWNER_LONG_NAME</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">, "
-        + "creator_info.LONG_NAME AS CREATOR_LONG_NAME</if>"
+        + "<if test='groupBySor != null'>, o.VALUE as SOR_VALUE </if><if"
+        + " test=\"addAttachmentColumnsToSelectClauseForOrdering\">, a.CLASSIFICATION_ID as"
+        + " ACLASSIFICATION_ID, a.CLASSIFICATION_KEY as ACLASSIFICATION_KEY, a.CHANNEL as ACHANNEL,"
+        + " a.REF_VALUE as AREF_VALUE, a.RECEIVED as ARECEIVED</if><if"
+        + " test=\"addClassificationNameToSelectClauseForOrdering\">, c.NAME as CNAME </if><if"
+        + " test=\"addAttachmentClassificationNameToSelectClauseForOrdering\">, ac.NAME as ACNAME"
+        + " </if><if test=\"addWorkbasketNameToSelectClauseForOrdering\">, w.NAME as WNAME </if><if"
+        + " test=\"joinWithUserInfoForTaskSummary\">, owner_info.LONG_NAME AS"
+        + " OWNER_LONG_NAME</if><if test=\"joinWithCreatorUserInfoForTaskSummary\">,"
+        + " creator_info.LONG_NAME AS CREATOR_LONG_NAME</if>"
         + groupByPorIfActive()
         + groupBySorIfActive()
         + "FROM TASK t "
@@ -76,10 +73,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfoForTaskSummary\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\"joinWithCreatorUserInfoForTaskSummary\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -87,8 +84,10 @@ public class TaskQuerySqlProvider {
         + commonTaskWhereStatement()
         + "<if test='selectAndClaim == true'> AND t.STATE = 'READY' </if>"
         + CLOSING_WHERE_TAG
-        + closeOuterClauseForGroupByPor()
-        + closeOuterClauseForGroupBySor()
+        + closeOuterClauseForGroupByPor(
+            "joinWithUserInfoForTaskSummary", "joinWithCreatorUserInfoForTaskSummary")
+        + closeOuterClauseForGroupBySor(
+            "joinWithUserInfoForTaskSummary", "joinWithCreatorUserInfoForTaskSummary")
         + "<if test='!orderByOuter.isEmpty()'>"
         + "ORDER BY <foreach item='item' collection='orderByOuter' separator=',' >${item}</foreach>"
         + "</if> "
@@ -124,8 +123,8 @@ public class TaskQuerySqlProvider {
         + "<if test=\"addClassificationNameToSelectClauseForOrdering\">, c.NAME </if>"
         + "<if test=\"addAttachmentClassificationNameToSelectClauseForOrdering\">, ac.NAME </if>"
         + "<if test=\"addWorkbasketNameToSelectClauseForOrdering\">, w.NAME </if>"
-        + "<if test=\"joinWithUserInfo\">, owner_info.LONG_NAME </if>"
-        + "<if test=\"joinWithCreatorUserInfo\">, creator_info.LONG_NAME </if>"
+        + "<if test=\"joinWithUserInfoForTaskSummary\">, owner_info.LONG_NAME </if>"
+        + "<if test=\"joinWithCreatorUserInfoForTaskSummary\">, creator_info.LONG_NAME </if>"
         + "FROM TASK t "
         + "<if test=\"joinWithAttachments\">"
         + "LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID "
@@ -142,10 +141,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfoForTaskSummary\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\"joinWithCreatorUserInfoForTaskSummary\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -208,18 +207,20 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithAttachmentClassifications\">"
         + "LEFT JOIN CLASSIFICATION ac ON a.CLASSIFICATION_ID = ac.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfoForCount\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\"joinWithCreatorUserInfoForCount\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
         + checkForAuthorization()
         + commonTaskWhereStatement()
         + CLOSING_WHERE_TAG
-        + closeOuterClauseForGroupByPor()
-        + closeOuterClauseForGroupBySor()
+        + closeOuterClauseForGroupByPor(
+            "joinWithUserInfoForCount", "joinWithCreatorUserInfoForCount")
+        + closeOuterClauseForGroupBySor(
+            "joinWithUserInfoForCount", "joinWithCreatorUserInfoForCount")
         + CLOSING_SCRIPT_TAG;
   }
 
@@ -241,10 +242,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithSecondaryObjectReferences\">"
         + "LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfoForCount\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\"joinWithCreatorUserInfoForCount\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -273,8 +274,6 @@ public class TaskQuerySqlProvider {
   public static String queryTaskColumnValues() {
     return OPENING_SCRIPT_TAG
         + "SELECT DISTINCT ${columnName} "
-        + "<if test=\"joinWithUserInfo\">, owner_info.LONG_NAME </if>"
-        + "<if test=\"joinWithCreatorUserInfo\">, creator_info.LONG_NAME </if>"
         + "FROM TASK t "
         + "<if test=\"joinWithAttachments\">"
         + "LEFT JOIN ATTACHMENT a ON t.ID = a.TASK_ID "
@@ -288,10 +287,10 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithSecondaryObjectReferences\">"
         + "LEFT JOIN OBJECT_REFERENCE o ON t.ID = o.TASK_ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\"joinWithUserInfoForColumnValues\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\"joinWithCreatorUserInfoForColumnValues\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -365,8 +364,8 @@ public class TaskQuerySqlProvider {
         + ", ACLASSIFICATION_ID, ACLASSIFICATION_KEY, CHANNEL, REF_VALUE, ARECEIVED"
         + "</if>"
         + "<if test=\"addWorkbasketNameToSelectClauseForOrdering\">, WNAME</if>"
-        + "<if test=\"joinWithUserInfo\">, OWNER_LONG_NAME </if>"
-        + "<if test=\"joinWithCreatorUserInfo\">, CREATOR_LONG_NAME </if>";
+        + "<if test=\"joinWithUserInfoForTaskSummary\">, OWNER_LONG_NAME </if>"
+        + "<if test=\"joinWithCreatorUserInfoForTaskSummary\">, CREATOR_LONG_NAME </if>";
   }
 
   private static String checkForAuthorization() {
@@ -427,7 +426,8 @@ public class TaskQuerySqlProvider {
     return "<if test=\"groupByPor or groupBySor != null\"> " + "SELECT * FROM (" + "</if> ";
   }
 
-  private static String closeOuterClauseForGroupByPor() {
+  private static String closeOuterClauseForGroupByPor(
+      String ownerUserInfoProperty, String creatorUserInfoProperty) {
     return "<if test=\"groupByPor\"> "
         + ") t LEFT JOIN"
         + " (SELECT POR_VALUE as PVALUE, COUNT(POR_VALUE) AS R_COUNT "
@@ -448,10 +448,14 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\""
+        + ownerUserInfoProperty
+        + "\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\""
+        + creatorUserInfoProperty
+        + "\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG
@@ -465,7 +469,8 @@ public class TaskQuerySqlProvider {
         + "</if> ";
   }
 
-  private static String closeOuterClauseForGroupBySor() {
+  private static String closeOuterClauseForGroupBySor(
+      String ownerUserInfoProperty, String creatorUserInfoProperty) {
     return "<if test='groupBySor != null'> "
         + ") t LEFT JOIN"
         + " (SELECT o.VALUE, COUNT(o.VALUE) AS R_COUNT "
@@ -483,10 +488,14 @@ public class TaskQuerySqlProvider {
         + "<if test=\"joinWithWorkbaskets\">"
         + "LEFT JOIN WORKBASKET w ON t.WORKBASKET_ID = w.ID "
         + "</if>"
-        + "<if test=\"joinWithUserInfo\">"
+        + "<if test=\""
+        + ownerUserInfoProperty
+        + "\">"
         + "LEFT JOIN USER_INFO owner_info ON t.OWNER = owner_info.USER_ID "
         + "</if>"
-        + "<if test=\"joinWithCreatorUserInfo\">"
+        + "<if test=\""
+        + creatorUserInfoProperty
+        + "\">"
         + "LEFT JOIN USER_INFO creator_info ON t.CREATOR = creator_info.USER_ID "
         + "</if>"
         + OPENING_WHERE_TAG


### PR DESCRIPTION
PostgreSQL benchmark with
- 1 Mio. tasks 
- 10,000 users

| Query | Before | After | Speedup |
|---|---:|---:|---:|
| Plain `count()` | 87.610 ms | 87.956 ms | 1.00× |
| `count()` + owner long-name filter | 157.936 ms | 157.588 ms | 1.00× |
| Grouped count + owner long-name sort | 3,716.782 ms | 3,678.735 ms | 1.01× |
| `listValues(NAME)` | 2,129.087 ms | 134.079 ms | **15.88×** |
| `listValues(OWNER_LONG_NAME)` | 1,561.972 ms | 272.305 ms | **5.74×** |
| `listValues(NAME)` + owner long-name filter | 321.452 ms | 161.963 ms | **1.98×** |
| `listValues(OWNER_LONG_NAME)` + creator long-name filter | 251.031 ms | 156.677 ms | **1.60×** |

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: