### PR TITLE
Closes #2168 - Validate Access-ID against the value that triggered the lookup

### DIFF
--- a/web/src/app/administration/components/workbasket-information/workbasket-information.component.ts
+++ b/web/src/app/administration/components/workbasket-information/workbasket-information.component.ts
@@ -169,6 +169,11 @@ export class WorkbasketInformationComponent implements OnInit, OnDestroy {
     this.formsValidatorService
       .validateFormInformation(this.workbasketForm(), this.toggleValidationMap)
       .then((value) => {
+        // discard submitting form if the request is stale
+        if (value === null) {
+          return;
+        }
+
         if (value && this.isOwnerValid) {
           this.onSave();
         } else {

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
@@ -22,7 +22,7 @@ import { FormsValidatorService } from './forms-validator.service';
 import { AccessIdsService } from 'app/shared/services/access-ids/access-ids.service';
 import { NotificationService } from '../notifications/notification.service';
 import { FormArray, FormControl } from '@angular/forms';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 const accessIdsServiceMock = {
   searchForAccessId: vi.fn().mockReturnValue(of([{ accessId: 'user1' }]))
@@ -173,6 +173,69 @@ describe('FormsValidatorService', () => {
       const toggleMap = new Map<any, boolean>();
       const result = await service.validateFormInformation(mockForm, toggleMap);
       expect(result).toBeFalsy();
+    });
+
+    it('should ignore stale async validation response if owner value changed while request was pending', async () => {
+      const accessIdSubject = new Subject<any[]>();
+      accessIdsServiceMock.searchForAccessId.mockReturnValue(accessIdSubject);
+
+      let mockOwnerValue = 'ownerA';
+      const mockForm: any = {
+        form: {
+          controls: {
+            'workbasket.owner': {
+              get value() {
+                return mockOwnerValue;
+              },
+              invalid: false,
+              valid: true
+            }
+          }
+        }
+      };
+
+      const toggleMap = new Map<any, boolean>();
+      const validationPromise = service.validateFormInformation(mockForm, toggleMap);
+      console.log(validationPromise);
+
+      mockOwnerValue = 'ownerB';
+
+      accessIdSubject.next([{ accessId: 'ownerA' }]);
+      accessIdSubject.complete();
+
+      const result = await validationPromise;
+
+      expect(result).toBe(false);
+    });
+
+    it('should accept async validation response when owner value remains unchanged', async () => {
+      const accessIdSubject = new Subject<any[]>();
+      accessIdsServiceMock.searchForAccessId.mockReturnValue(accessIdSubject);
+
+      let mockOwnerValue = 'ownerA';
+      const mockForm: any = {
+        form: {
+          controls: {
+            'workbasket.owner': {
+              get value() {
+                return mockOwnerValue;
+              },
+              invalid: false,
+              valid: true
+            }
+          }
+        }
+      };
+
+      const toggleMap = new Map<any, boolean>();
+      const validationPromise = service.validateFormInformation(mockForm, toggleMap);
+
+      accessIdSubject.next([{ accessId: 'ownerA' }]);
+      accessIdSubject.complete();
+
+      const result = await validationPromise;
+
+      expect(result).toBe(true);
     });
   });
 

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
@@ -175,7 +175,7 @@ describe('FormsValidatorService', () => {
       expect(result).toBeFalsy();
     });
 
-    it('should ignore stale async validation response if owner value changed while request was pending', async () => {
+    it('should ignore stale async validation response and return null if owner value changed while request was pending', async () => {
       const accessIdSubject = new Subject<any[]>();
       accessIdsServiceMock.searchForAccessId.mockReturnValue(accessIdSubject);
 
@@ -205,7 +205,7 @@ describe('FormsValidatorService', () => {
       const result = await validationPromise;
 
       expect(notificationServiceMock.showError).not.toHaveBeenCalled();
-      expect(result).toBe(false);
+      expect(result).toBe(null);
     });
 
     it('should accept async validation response when owner value remains unchanged', async () => {

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
@@ -16,12 +16,12 @@
  *
  */
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FormsValidatorService } from './forms-validator.service';
 import { AccessIdsService } from 'app/shared/services/access-ids/access-ids.service';
 import { NotificationService } from '../notifications/notification.service';
-import { FormArray, FormControl } from '@angular/forms';
+import { FormArray, FormControl, NgForm } from '@angular/forms';
 import { of, Subject } from 'rxjs';
 
 const accessIdsServiceMock = {
@@ -196,15 +196,15 @@ describe('FormsValidatorService', () => {
 
       const toggleMap = new Map<any, boolean>();
       const validationPromise = service.validateFormInformation(mockForm, toggleMap);
-      console.log(validationPromise);
 
       mockOwnerValue = 'ownerB';
 
-      accessIdSubject.next([{ accessId: 'ownerA' }]);
+      accessIdSubject.next([{ accessId: 'ownerB' }]);
       accessIdSubject.complete();
 
       const result = await validationPromise;
 
+      expect(notificationServiceMock.showError).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
 

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
@@ -16,12 +16,12 @@
  *
  */
 
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FormsValidatorService } from './forms-validator.service';
 import { AccessIdsService } from 'app/shared/services/access-ids/access-ids.service';
 import { NotificationService } from '../notifications/notification.service';
-import { FormArray, FormControl, NgForm } from '@angular/forms';
+import { FormArray, FormControl } from '@angular/forms';
 import { of, Subject } from 'rxjs';
 
 const accessIdsServiceMock = {

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -38,6 +38,10 @@ export class FormsValidatorService {
     return this.inputOverflow.asObservable();
   }
 
+  // 1. returns true if the form is valid, 
+  // 2. false if not valid 
+  // 3. and null if the async validation response is stale 
+  // (the user changed the value in the meantime)
   async validateFormInformation(form: NgForm | undefined, toggleValidationMap: Map<any, boolean>): Promise<any> {
     let validSync = true;
     if (!form) {
@@ -72,8 +76,7 @@ export class FormsValidatorService {
           const validationState = toggleValidationMap.get(this.workbasketOwner);
           toggleValidationMap.set(this.workbasketOwner, !validationState);
           const matches = items.some((item) => item.accessId === requestedOwnerValue);
-          const valid = stillCurrent && matches;
-          resolve(new ResponseOwner({ valid, field: ownerString }));
+          resolve(new ResponseOwner({ valid: matches, field: ownerString }));
         });
       } else {
         const validationState = toggleValidationMap.get(form.form.controls[this.workbasketOwner]);
@@ -83,8 +86,9 @@ export class FormsValidatorService {
     });
 
     const values = await Promise.all([forFieldsPromise, ownerPromise]);
+    // return null in case of stale request
     if (values[1] === null) {
-      return false;
+      return null;
     }
 
     const responseOwner = new ResponseOwner(values[1]);

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -38,9 +38,9 @@ export class FormsValidatorService {
     return this.inputOverflow.asObservable();
   }
 
-  // 1. returns true if the form is valid, 
-  // 2. false if not valid 
-  // 3. and null if the async validation response is stale 
+  // 1. returns true if the form is valid,
+  // 2. false if not valid
+  // 3. and null if the async validation response is stale
   // (the user changed the value in the meantime)
   async validateFormInformation(form: NgForm | undefined, toggleValidationMap: Map<any, boolean>): Promise<any> {
     let validSync = true;

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -56,11 +56,17 @@ export class FormsValidatorService {
 
     const ownerPromise = new Promise((resolve) => {
       const ownerString = 'owner';
-      if (form.form.controls[this.workbasketOwner]) {
-        this.accessIdsService.searchForAccessId(form.form.controls[this.workbasketOwner].value).subscribe((items) => {
+      const ownerControl = form.form.controls[this.workbasketOwner];
+
+      if (ownerControl) {
+        const requestedOwnerValue = ownerControl.value;
+
+        this.accessIdsService.searchForAccessId(requestedOwnerValue).subscribe((items) => {
           const validationState = toggleValidationMap.get(this.workbasketOwner);
           toggleValidationMap.set(this.workbasketOwner, !validationState);
-          const valid = items.find((item) => item.accessId === form.form.controls[this.workbasketOwner].value);
+          const stillCurrent = ownerControl.value === requestedOwnerValue;
+          const matches = items.some((item) => item.accessId === requestedOwnerValue);
+          const valid = stillCurrent && matches;
           resolve(new ResponseOwner({ valid, field: ownerString }));
         });
       } else {

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -62,9 +62,15 @@ export class FormsValidatorService {
         const requestedOwnerValue = ownerControl.value;
 
         this.accessIdsService.searchForAccessId(requestedOwnerValue).subscribe((items) => {
+          const stillCurrent = ownerControl.value === requestedOwnerValue;
+
+          if (!stillCurrent) {
+            resolve(null);
+            return;
+          }
+
           const validationState = toggleValidationMap.get(this.workbasketOwner);
           toggleValidationMap.set(this.workbasketOwner, !validationState);
-          const stillCurrent = ownerControl.value === requestedOwnerValue;
           const matches = items.some((item) => item.accessId === requestedOwnerValue);
           const valid = stillCurrent && matches;
           resolve(new ResponseOwner({ valid, field: ownerString }));
@@ -77,6 +83,10 @@ export class FormsValidatorService {
     });
 
     const values = await Promise.all([forFieldsPromise, ownerPromise]);
+    if (values[1] === null) {
+      return false;
+    }
+
     const responseOwner = new ResponseOwner(values[1]);
     if (!(values[0] && responseOwner.valid)) {
       if (!responseOwner.valid) {


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
    - Fixed an issue where changing the owner field during async validation could accept stale responses for the previous value.