### PR TITLE
Closes #2169 - Require exact Access-ID matches when validating workbasket access items

### DIFF
--- a/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.spec.ts
@@ -202,12 +202,50 @@ describe('FormsValidatorService', () => {
       expect(result).toBe(true);
     });
 
+    it('should resolve to true when access ID matches case-insensitively', async () => {
+      accessIdsServiceMock.searchForAccessId.mockReturnValue(of([{ accessId: 'USER1' }]));
+
+      const formArray = new FormArray([
+        new FormControl({
+          accessId: 'user1',
+          permRead: true,
+          permReadTasks: false,
+          permEditTasks: false,
+          permOpen: false,
+          permAppend: false,
+          permTransfer: false,
+          permDistribute: false
+        })
+      ]);
+      const result = await service.validateFormAccess(formArray, new Map());
+      expect(result).toBe(true);
+    });
+
     it('should resolve to false when an access ID is not found', async () => {
       accessIdsServiceMock.searchForAccessId.mockReturnValue(of([]));
 
       const formArray = new FormArray([
         new FormControl({
           accessId: 'unknownUser',
+          permRead: false,
+          permReadTasks: false,
+          permEditTasks: false,
+          permOpen: false,
+          permAppend: false,
+          permTransfer: false,
+          permDistribute: false
+        })
+      ]);
+      const result = await service.validateFormAccess(formArray, new Map());
+      expect(result).toBe(false);
+    });
+
+    it('should resolve to false when search returns only fuzzy matches', async () => {
+      accessIdsServiceMock.searchForAccessId.mockReturnValue(of([{ accessId: 'user-a' }, { accessId: 'user-b' }]));
+
+      const formArray = new FormArray([
+        new FormControl({
+          accessId: 'user',
           permRead: false,
           permReadTasks: false,
           permEditTasks: false,

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -90,8 +90,15 @@ export class FormsValidatorService {
         new Promise((resolve) => {
           const validationState = toggleValidationAccessIdMap.get(i);
           toggleValidationAccessIdMap.set(i, !validationState);
-          this.accessIdsService.searchForAccessId(form.controls[i].value.accessId).subscribe((items) => {
-            resolve(new ResponseOwner({ valid: items.length > 0, field: 'access id' }));
+
+          const enteredAccessId = form.controls[i].value?.accessId;
+
+          this.accessIdsService.searchForAccessId(enteredAccessId).subscribe((items) => {
+            const isValid = items
+              ? items.some((item) => item.accessId?.toLowerCase() === enteredAccessId?.toLowerCase())
+              : false;
+
+            resolve(new ResponseOwner({ valid: isValid, field: 'access id' }));
           });
         })
       );


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION` 
  - is present as single-commit already or
  - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
    - Fixed workbasket access item validation to require an exact, case-insensitive Access-ID match and reject partial or fuzzy search results.